### PR TITLE
Version prefix as a postfix on all components

### DIFF
--- a/src/main/resources/build.yaml
+++ b/src/main/resources/build.yaml
@@ -137,7 +137,7 @@ builds:
 - name: kubernetes-client-3.0.3-${version.fuse.prefix}
   project: fabric8io/kubernetes-client
     #externalScmUrl: git+https://code.engineering.redhat.com/gerrit/jboss-fuse/camel.git
-  scmUrl: git+ssh://code.stage.engineering.redhat.com/fabric8io-kubernetes-client.git
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8io-kubernetes-client.git
   scmRevision: kubernetes-client-${version.kubernetes.client}
   dependencies:
   - kubernetes-model-2.0.9-${version.fuse.prefix}
@@ -153,7 +153,7 @@ builds:
 
 - name: docker-maven-plugin-0.23.0-${version.fuse.prefix}
   project: fabric8io/docker-maven-plugin
-  scmUrl: git+ssh://code.stage.engineering.redhat.com/fabric8io-docker-maven-plugin.git
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8io-docker-maven-plugin.git
   scmRevision: docker-maven-plugin-${docker.maven.plugin.version}
   dependencies:
   - spring-cloud-kubernetes-0.1.6-${version.fuse.prefix}
@@ -185,7 +185,7 @@ builds:
 
 - name: ipaas-quickstarts-2.2.0-${version.fuse.prefix}
   project: fabric8io/ipaas-quickstarts
-  scmUrl: git+ssh://code.stage.engineering.redhat.com/fabric8io-ipaas-quickstarts.git
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8io-ipaas-quickstarts.git
   scmRevision: ipaas-quickstarts-${version.ipaas.quickstarts}
   buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false -P clean
     deploy -Dquickstart.git.repos=repolist.txt'


### PR DESCRIPTION
In order to ensure we don't rebuild 7.0 components when kicking off 7.1 builds i think we need to add the 7.1.0 prefix as a postfix to all build configs. Its a bit verbose but it should ensure the buildconfigs remain unique and we don't lose the ability to kick off two 7.x versions at a time.

These changes should reflect that, though i've not had the chance to test this yet.  