### PR TITLE
Fix dependency typo, comment out application-templates

### DIFF
--- a/src/main/resources/build.yaml
+++ b/src/main/resources/build.yaml
@@ -223,12 +223,12 @@ builds:
     install '
   scmRevision: kubernetes-model-${version.kubernetes.model}
 
-- name: application-templates-2.1-${version.fuse.prefix}
-  project: jboss-fuse/application-templates
-  scmUrl: git+ssh://code.engineering.redhat.com/jboss-fuse/application-templates.git
-  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false -P clean
-    install '
-  scmRevision: application-templates-${version.application.templates}
+#- name: application-templates-2.1-${version.fuse.prefix}
+#  project: jboss-fuse/application-templates
+#  scmUrl: git+ssh://code.engineering.redhat.com/jboss-fuse/application-templates.git
+#  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false -P clean
+#    install '
+#  scmRevision: application-templates-${version.application.templates}
 
 outputPrefixes:
   releaseFile: fuse-test

--- a/src/main/resources/build.yaml
+++ b/src/main/resources/build.yaml
@@ -129,7 +129,7 @@ builds:
   buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false -Psap
     clean deploy '
   dependencies:
-  - fuse-components-7.0.0-${version.fuse.prefix}
+  - fuse-components-${version.fuse.prefix}
   - karaf-4.2.0-${version.fuse.prefix}
   - hawtio-2.0.0-${version.fuse.prefix}
   - camel-2.21.0-${version.fuse.prefix}


### PR DESCRIPTION
There was a bit of a typo introduced by my last changes with a dependency to ``fuse-components-7.0.0-${version.fuse.prefix}`` which is incorrect

I've also commented out the application-templates for now so manual intervention is required to remove it/comment it out, its not actually built in PNC at the minute.

I've been testing this with 
```
mvn org.apache.maven.plugins:maven-dependency-plugin:3.1.1:get -DremoteRepositories=jboss::default::https://origin-repository.jboss.org/nexus/service/local/repositories/ea/content/ -Dartifact=com.redhat.fuse:fuse-build-yaml:LATEST:yaml:yaml && cp ~/.m2/repository/com/redhat/fuse/fuse-build-yaml/*/*.yaml . && mv *.yaml build-config.yaml && mkdir build-config && mv build-config.yaml build-config
```

```
docker run -v ${PWD}/build-config:/home/jenkins/buildconfig/ -ePNC_USER=myusername -ePNC_PASSWORD='hunter2' -ePNC_URL=http://x.redhat.com/ -e VERBOSE=true -ePNC_KEYCLOAK_URL=https://x.redhat.com/ -it docker-registry.engineering.redhat.com/jboss-prod-ipt/prod-files-generator
```