### PR TITLE
Fixes for dependency ordering

### DIFF
--- a/Fuse7Deps.html
+++ b/Fuse7Deps.html
@@ -1,0 +1,86 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html> <head>
+<title>Fuse 7 Dependencies</title>
+<script type="text/javascript" src="http://visjs.org/dist/vis.js"></script>
+<link href="http://visjs.org/dist/vis.css" rel="stylesheet" type="text/css" />
+</head>
+
+<body>
+<h1>Fuse 7 Dependencies</h1>
+
+<div id="deptree"></div>
+
+<script type="text/javascript">
+var components = new vis.DataSet([
+{ id: 1, label: 'Karaf' },
+{ id: 2, label: 'CXF XJC Utils' },
+{ id: 3, label: 'CXF' },
+{ id: 4, label: 'Camel' },
+{ id: 5, label: 'Fuse Extras Distro' },
+{ id: 6, label: 'Camel Extra' },
+{ id: 7, label: 'Wsdl2rest' },
+{ id: 8, label: 'Fuse Components' },
+{ id: 9, label: 'HawtIO' },
+{ id: 10, label: 'HawtIO Online' },
+{ id: 11, label: 'Fuse Karaf' },
+{ id: 12, label: 'Kubernetes Model' },
+{ id: 13, label: 'Kubernetes Client' },
+{ id: 14, label: 'Spring Cloud Kubernetes' },
+{ id: 15, label: 'Docker Maven Plugin' },
+{ id: 16, label: 'Fabric8 v2' },
+{ id: 17, label: 'Fabric8 Maven Plugin' },
+{ id: 18, label: 'Fuse Patch' },
+{ id: 19, label: 'Wildfly Camel' },
+{ id: 20, label: 'Wildfly Camel Examples' },
+{ id: 21, label: 'Fuse EAP' },
+{ id: 22, label: 'Red Hat Fuse' },
+{ id: 23, label: 'iPaaS Quickstarts' },
+{ id: 24, label: 'AtlasMap' },
+{ id: 25, label: 'Syndesis' }
+]);
+
+var dependencies = new vis.DataSet([
+{ from: 3, to: 1, arrows: 'to' },
+{ from: 3, to: 2, arrows: 'to' },
+{ from: 4, to: 1, arrows: 'to' },
+{ from: 4, to: 3, arrows: 'to' },
+{ from: 5, to: 4, arrows: 'to' },
+{ from: 6, to: 4, arrows: 'to' },
+{ from: 7, to: 4, arrows: 'to' },
+{ from: 8, to: 4, arrows: 'to' },
+{ from: 9, to: 4, arrows: 'to' },
+{ from: 11, to: 6, arrows: 'to' },
+{ from: 11, to: 8, arrows: 'to' },
+{ from: 11, to: 9, arrows: 'to' },
+{ from: 13, to: 12, arrows: 'to' },
+{ from: 14, to: 13, arrows: 'to' },
+{ from: 16, to: 11, arrows: 'to' },
+{ from: 16, to: 15, arrows: 'to' },
+{ from: 16, to: 14, arrows: 'to' },
+{ from: 17, to: 16, arrows: 'to' },
+{ from: 19, to: 18, arrows: 'to' },
+{ from: 19, to: 8, arrows: 'to' },
+{ from: 19, to: 9, arrows: 'to' },
+{ from: 20, to: 19, arrows: 'to' },
+{ from: 21, to: 20, arrows: 'to' },
+{ from: 22, to: 21, arrows: 'to' },
+{ from: 22, to: 11, arrows: 'to' },
+{ from: 22, to: 17, arrows: 'to' },
+{ from: 23, to: 16, arrows: 'to' },
+{ from: 24, to: 4, arrows: 'to' },
+{ from: 25, to: 24, arrows: 'to' }
+]);
+
+var container = document.getElementById('deptree');
+var data = {
+   nodes: components,
+   edges: dependencies
+};
+
+var options = {
+};
+
+var deptree = new vis.Network(container, data, options);
+</script>
+</body> </html>
+

--- a/src/main/resources/build.yaml
+++ b/src/main/resources/build.yaml
@@ -42,6 +42,7 @@ builds:
     -Pdeploy clean deploy'
   dependencies:
   - cxf-xjc-utils-3.1.1-${version.fuse.prefix}
+  - karaf-4.2.0-${version.fuse.prefix}
 
 - name: camel-2.21.0-${version.fuse.prefix}
   project: jboss-fuse/camel
@@ -155,13 +156,13 @@ builds:
   project: fabric8io/docker-maven-plugin
   scmUrl: git+ssh://code.engineering.redhat.com/fabric8io-docker-maven-plugin.git
   scmRevision: docker-maven-plugin-${docker.maven.plugin.version}
-  dependencies:
-  - spring-cloud-kubernetes-0.1.6-${version.fuse.prefix}
 
 - name: fabric8-maven-plugin-3.5.33-${version.fuse.prefix}
   project: fabric8io/fabric8-maven-plugin
   scmUrl: git+ssh://code.engineering.redhat.com/fabric8io-fabric8-maven-plugin.git
   scmRevision: fabric8-maven-plugin-${version.fabric8.maven.plugin}
+  dependencies:
+  - fabric8v2-3.0.11-${version.fuse.prefix} 
 
 - name: fuse-patch-3.0.0-${version.fuse.prefix}
   project: jboss-fuse/fuse-patch
@@ -172,28 +173,22 @@ builds:
   project: jboss-fuse/wildfly-camel
   scmUrl: git+ssh://code.engineering.redhat.com/jboss-fuse/wildfly-camel.git
   scmRevision: wildfly-camel-${version.bom.wildfly.camel}
+  dependencies:
+  - fuse-components-${version.fuse.prefix}
 
 - name: wildfly-camel-examples-5.1.0-${version.fuse.prefix}
   project: wildfly-extras/wildfly-camel-examples
   scmUrl: git+ssh://code.engineering.redhat.com/wildfly-extras/wildfly-camel-examples.git
   scmRevision: wildfly-camel-examples-${version.wildfly.camel.examples}
+  dependencies:
+  - wildfly-camel-5.1.0-${version.fuse.prefix}
 
 - name: fuse-eap-${version.fuse.prefix}
   project: jboss-fuse/fuse-eap
   scmUrl: git+ssh://code.engineering.redhat.com/jboss-fuse/fuse-eap.git
   scmRevision: fuse-eap-${version.fuse.eap}
-
-- name: ipaas-quickstarts-2.2.0-${version.fuse.prefix}
-  project: fabric8io/ipaas-quickstarts
-  scmUrl: git+ssh://code.engineering.redhat.com/fabric8io-ipaas-quickstarts.git
-  scmRevision: ipaas-quickstarts-${version.ipaas.quickstarts}
-  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false -P clean
-    deploy -Dquickstart.git.repos=repolist.txt'
-
-- name: fabric8v2-3.0.11-${version.fuse.prefix}
-  project: jboss-fuse/fabric8
-  scmUrl: git+ssh://code.engineering.redhat.com/fabric8io-fabric8.git
-  scmRevision: fabric8v2-${version.fabric8}
+  dependencies:
+  - wildfly-camel-examples-5.1.0-${version.fuse.prefix}
 
 - name: redhat-fuse-${version.fuse.prefix}
   project: jboss-fuse/redhat-fuse
@@ -201,6 +196,27 @@ builds:
   scmRevision: redhat-fuse-${fuse-bom.version}
   buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false -P clean
     deploy -DskipClean'
+  dependencies:
+  - fuse-karaf-${version.fuse.prefix}
+  - fuse-eap-${version.fuse.prefix}
+  - fabric8-maven-plugin-3.5.33-${version.fuse.prefix}
+
+- name: ipaas-quickstarts-2.2.0-${version.fuse.prefix}
+  project: fabric8io/ipaas-quickstarts
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8io-ipaas-quickstarts.git
+  scmRevision: ipaas-quickstarts-${version.ipaas.quickstarts}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false -P clean
+    deploy -Dquickstart.git.repos=repolist.txt'
+  dependencies:
+  - fabric8v2-3.0.11-${version.fuse.prefix} 
+
+- name: fabric8v2-3.0.11-${version.fuse.prefix}
+  project: jboss-fuse/fabric8
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8io-fabric8.git
+  scmRevision: fabric8v2-${version.fabric8}
+  dependencies:
+  - docker-maven-plugin-0.23.0-${version.fuse.prefix}
+  - spring-cloud-kubernetes-0.1.6-${version.fuse.prefix}
 
 - name: cxf-xjc-utils-3.1.1-${version.fuse.prefix}
   project: jboss-fuse/cxf-xjc-utils

--- a/src/main/resources/build.yaml
+++ b/src/main/resources/build.yaml
@@ -4,7 +4,7 @@ product:
   stage: EA1
   issueTrackerUrl: http://issues.jboss.org/browse/ENTESB
 version: ${version.fuse.prefix}
-milestone: Sprint 30
+milestone: Sprint30
 group: Fuse Standalone and FIS 7.1
 defaultBuildParameters:
   environmentId: 1


### PR DESCRIPTION
Summary of changes 

- Altered the dependency ordering to avoid failed builds due to missing deps
- Remove space from milestone name, PNC see the second value as its space separated 