### PR TITLE
Fix missing key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,6 @@
 
     <plugins>
 
-<!--
     <plugin>
         <groupId>org.codehaus.gmaven</groupId>
         <artifactId>groovy-maven-plugin</artifactId>
@@ -261,7 +260,7 @@
             </dependency>
         </dependencies>
     </plugin>
--->    
+    
     <plugin> 
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/src/main/groovy/formatYaml.groovy
+++ b/src/main/groovy/formatYaml.groovy
@@ -249,6 +249,22 @@ class BuildConfigSection {
         }
     }
 
+    public boolean checkKeysPresent()
+    {
+        def neededkeys = ["name", "project", "scmUrl", "scmRevision"]
+        def ret = false
+        for(k in neededkeys)
+        {
+            ret = getAdjusted()[0].containsKey(k)
+            if(!ret)
+            {
+                log.error("$k is missing!")
+                return ret
+            }
+        }
+        return ret
+    }
+
     public void adjustProjectName()
     {
         def project = getAdjusted()[0]['project']
@@ -267,6 +283,7 @@ class BuildConfigSection {
         def uri =  new URI(fixeduri)
         def path = uri.getPath()
 
+        log.debug("URI: $uri, path:$path, project:$project")
         def (repo, proj) = project.split("/")
         //work around for fabric8io- instead of fabric8io/
         def splpath = path.split("/")
@@ -452,6 +469,8 @@ class BuildConfig {
         def buildsections = this.preParse(rawFileContents)
         for(section in buildsections)
         {
+            //Sanity check
+            assert section.checkKeysPresent()
             //Use github (upstream/midstream)
         //section.swapInternalAndExternalURL()
             //Change the BC name to match the scm tag ver

--- a/src/main/resources/fusefis.yaml
+++ b/src/main/resources/fusefis.yaml
@@ -403,6 +403,7 @@ builds:
     #pushScmUrl: ${narayana-spring-boot.push.scmUrl}
     #tag: ${narayana-spring-boot.tag}
     #buildCommand: ${narayana-spring-boot.buildCommand}
+  project: jboss-fuse/narayana-spring-boot
   scmUrl: git+ssh://code.engineering.redhat.com/jboss-fuse/narayana-spring-boot.git
   scmRevision: narayana-spring-boot-1.0.2.fuse-710001
   buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false -P clean deploy -DskipClean'


### PR DESCRIPTION
There was a missing k:v pair (project: jboss-fuse/narayana-spring-boot) which is fixed in 
ac8ca23 I also added a check/assert for this in future.

We can leave this out, if the risk is too great of this failing (and also failing the pipeline?) It can easily be ran manually and in fact only produces resources locally at the minute