### PR TITLE
Fixes done in CR1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,10 @@
     <narayana-spring-boot.fetch.scmUrl>1</narayana-spring-boot.fetch.scmUrl>
     <narayana-spring-boot.push.scmUrl>1</narayana-spring-boot.push.scmUrl>
     <narayana-spring-boot.buildCommand>1</narayana-spring-boot.buildCommand>
+    <spring-boot-camel-xa.tag>1</spring-boot-camel-xa.tag>
+    <spring-boot-camel-xa.fetch.scmUrl>1</spring-boot-camel-xa.fetch.scmUrl>
+    <spring-boot-camel-xa.push.scmUrl>1</spring-boot-camel-xa.push.scmUrl>
+    <spring-boot-camel-xa.buildCommand>1</spring-boot-camel-xa.buildCommand>
     <fabric8v2.tag>1</fabric8v2.tag>
     <fabric8v2.fetch.scmUrl>1</fabric8v2.fetch.scmUrl>
     <fabric8v2.push.scmUrl>1</fabric8v2.push.scmUrl>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,10 @@
     <version.wildfly.camel.examples>5.1.0.fuse-000047</version.wildfly.camel.examples>
     <version.fuse.eap>7.0.1.fuse-000001</version.fuse.eap>
 
+    <!-- build information -->
+    <build.stage>EA</build.stage>
+    <build.milestone>EA*</build.milestone>
+
     <!-- quickstarts -->
     <karaf-camel-amq.version>1.0.0.fuse-710004</karaf-camel-amq.version>
     <karaf-camel-log.version>1.0.0.fuse-710004</karaf-camel-log.version>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,9 @@
     <build.stage>EA</build.stage>
     <build.milestone>EA*</build.milestone>
 
+    <!-- pom manipulation scripts version (global) -->
+    <version.pom-manipulation>1.0.8.redhat-00001</version.pom-manipulation>
+
     <!-- quickstarts -->
     <karaf-camel-amq.version>1.0.0.fuse-710004</karaf-camel-amq.version>
     <karaf-camel-log.version>1.0.0.fuse-710004</karaf-camel-log.version>

--- a/pom.xml
+++ b/pom.xml
@@ -99,47 +99,47 @@
     <spring-boot-cxf-jaxws.version>1.0.0.fuse-710004</spring-boot-cxf-jaxws.version>
 
     <!-- Tag and SCM info -->
-    <karaf.tag>1</karaf.tag>
+    <karaf.tag>DUMMY-TAG-0.0.0</karaf.tag>
     <karaf.fetch.scmUrl>1</karaf.fetch.scmUrl>
     <karaf.push.scmUrl>1</karaf.push.scmUrl>
     <karaf.buildCommand>1</karaf.buildCommand>
-    <cxf-xjc-utils.tag>1</cxf-xjc-utils.tag>
+    <cxf-xjc-utils.tag>DUMMY-TAG-0.0.0</cxf-xjc-utils.tag>
     <cxf-xjc-utils.fetch.scmUrl>1</cxf-xjc-utils.fetch.scmUrl>
     <cxf-xjc-utils.push.scmUrl>1</cxf-xjc-utils.push.scmUrl>
     <cxf-xjc-utils.buildCommand>1</cxf-xjc-utils.buildCommand>
-    <cxf.tag>1</cxf.tag>
+    <cxf.tag>DUMMY-TAG-0.0.0</cxf.tag>
     <cxf.fetch.scmUrl>1</cxf.fetch.scmUrl>
     <cxf.push.scmUrl>1</cxf.push.scmUrl>
     <cxf.buildCommand>1</cxf.buildCommand>
-    <camel.tag>1</camel.tag>
+    <camel.tag>DUMMY-TAG-0.0.0</camel.tag>
     <camel.fetch.scmUrl>1</camel.fetch.scmUrl>
     <camel.push.scmUrl>1</camel.push.scmUrl>
     <camel.buildCommand>1</camel.buildCommand>
-    <fuse-extras-distro.tag>1</fuse-extras-distro.tag>
+    <fuse-extras-distro.tag>DUMMY-TAG-0.0.0</fuse-extras-distro.tag>
     <fuse-extras-distro.fetch.scmUrl>1</fuse-extras-distro.fetch.scmUrl>
     <fuse-extras-distro.push.scmUrl>1</fuse-extras-distro.push.scmUrl>
     <fuse-extras-distro.buildCommand>1</fuse-extras-distro.buildCommand>
-    <camel-extra.tag>1</camel-extra.tag>
+    <camel-extra.tag>DUMMY-TAG-0.0.0</camel-extra.tag>
     <camel-extra.fetch.scmUrl>1</camel-extra.fetch.scmUrl>
     <camel-extra.push.scmUrl>1</camel-extra.push.scmUrl>
     <camel-extra.buildCommand>1</camel-extra.buildCommand>
-    <wsdl2rest.tag>1</wsdl2rest.tag>
+    <wsdl2rest.tag>DUMMY-TAG-0.0.0</wsdl2rest.tag>
     <wsdl2rest.fetch.scmUrl>1</wsdl2rest.fetch.scmUrl>
     <wsdl2rest.push.scmUrl>1</wsdl2rest.push.scmUrl>
     <wsdl2rest.buildCommand>1</wsdl2rest.buildCommand>
-    <fuse-components.tag>1</fuse-components.tag>
+    <fuse-components.tag>DUMMY-TAG-0.0.0</fuse-components.tag>
     <fuse-components.fetch.scmUrl>1</fuse-components.fetch.scmUrl>
     <fuse-components.push.scmUrl>1</fuse-components.push.scmUrl>
     <fuse-components.buildCommand>1</fuse-components.buildCommand>
-    <hawtio.tag>1</hawtio.tag>
+    <hawtio.tag>DUMMY-TAG-0.0.0</hawtio.tag>
     <hawtio.fetch.scmUrl>1</hawtio.fetch.scmUrl>
     <hawtio.push.scmUrl>1</hawtio.push.scmUrl>
     <hawtio.buildCommand>1</hawtio.buildCommand>
-    <hawtio-online.tag>1</hawtio-online.tag>
+    <hawtio-online.tag>DUMMY-TAG-0.0.0</hawtio-online.tag>
     <hawtio-online.fetch.scmUrl>1</hawtio-online.fetch.scmUrl>
     <hawtio-online.push.scmUrl>1</hawtio-online.push.scmUrl>
     <hawtio-online.buildCommand>1</hawtio-online.buildCommand>
-    <fuse-karaf.tag>1</fuse-karaf.tag>
+    <fuse-karaf.tag>DUMMY-TAG-0.0.0</fuse-karaf.tag>
     <fuse-karaf.fetch.scmUrl>1</fuse-karaf.fetch.scmUrl>
     <fuse-karaf.push.scmUrl>1</fuse-karaf.push.scmUrl>
     <fuse-karaf.buildCommand>1</fuse-karaf.buildCommand>
@@ -147,63 +147,63 @@
     <kubernetes-model.fetch.scmUrl>1</kubernetes-model.fetch.scmUrl>
     <kubernetes-model.push.scmUrl>1</kubernetes-model.push.scmUrl>
     <kubernetes-model.buildCommand>1</kubernetes-model.buildCommand>
-    <kubernetes-client.tag>1</kubernetes-client.tag>
+    <kubernetes-client.tag>DUMMY-TAG-0.0.0</kubernetes-client.tag>
     <kubernetes-client.fetch.scmUrl>1</kubernetes-client.fetch.scmUrl>
     <kubernetes-client.push.scmUrl>1</kubernetes-client.push.scmUrl>
     <kubernetes-client.buildCommand>1</kubernetes-client.buildCommand>
-    <spring-cloud-kubernetes.tag>1</spring-cloud-kubernetes.tag>
+    <spring-cloud-kubernetes.tag>DUMMY-TAG-0.0.0</spring-cloud-kubernetes.tag>
     <spring-cloud-kubernetes.fetch.scmUrl>1</spring-cloud-kubernetes.fetch.scmUrl>
     <spring-cloud-kubernetes.push.scmUrl>1</spring-cloud-kubernetes.push.scmUrl>
     <spring-cloud-kubernetes.buildCommand>1</spring-cloud-kubernetes.buildCommand>
-    <docker-maven-plugin.tag>1</docker-maven-plugin.tag>
+    <docker-maven-plugin.tag>DUMMY-TAG-0.0.0</docker-maven-plugin.tag>
     <docker-maven-plugin.fetch.scmUrl>1</docker-maven-plugin.fetch.scmUrl>
     <docker-maven-plugin.push.scmUrl>1</docker-maven-plugin.push.scmUrl>
     <docker-maven-plugin.buildCommand>1</docker-maven-plugin.buildCommand>
-    <narayana-spring-boot.tag>1</narayana-spring-boot.tag>
+    <narayana-spring-boot.tag>DUMMY-TAG-0.0.0</narayana-spring-boot.tag>
     <narayana-spring-boot.fetch.scmUrl>1</narayana-spring-boot.fetch.scmUrl>
     <narayana-spring-boot.push.scmUrl>1</narayana-spring-boot.push.scmUrl>
     <narayana-spring-boot.buildCommand>1</narayana-spring-boot.buildCommand>
-    <spring-boot-camel-xa.tag>1</spring-boot-camel-xa.tag>
+    <spring-boot-camel-xa.tag>DUMMY-TAG-0.0.0</spring-boot-camel-xa.tag>
     <spring-boot-camel-xa.fetch.scmUrl>1</spring-boot-camel-xa.fetch.scmUrl>
     <spring-boot-camel-xa.push.scmUrl>1</spring-boot-camel-xa.push.scmUrl>
     <spring-boot-camel-xa.buildCommand>1</spring-boot-camel-xa.buildCommand>
-    <fabric8v2.tag>1</fabric8v2.tag>
+    <fabric8v2.tag>DUMMY-TAG-0.0.0</fabric8v2.tag>
     <fabric8v2.fetch.scmUrl>1</fabric8v2.fetch.scmUrl>
     <fabric8v2.push.scmUrl>1</fabric8v2.push.scmUrl>
     <fabric8v2.buildCommand>1</fabric8v2.buildCommand>
-    <fabric8-maven-plugin.tag>1</fabric8-maven-plugin.tag>
+    <fabric8-maven-plugin.tag>DUMMY-TAG-0.0.0</fabric8-maven-plugin.tag>
     <fabric8-maven-plugin.fetch.scmUrl>1</fabric8-maven-plugin.fetch.scmUrl>
     <fabric8-maven-plugin.push.scmUrl>1</fabric8-maven-plugin.push.scmUrl>
     <fabric8-maven-plugin.buildCommand>1</fabric8-maven-plugin.buildCommand>
-    <fuse-patch.tag>1</fuse-patch.tag>
+    <fuse-patch.tag>DUMMY-TAG-0.0.0</fuse-patch.tag>
     <fuse-patch.fetch.scmUrl>1</fuse-patch.fetch.scmUrl>
     <fuse-patch.push.scmUrl>1</fuse-patch.push.scmUrl>
     <fuse-patch.buildCommand>1</fuse-patch.buildCommand>
-    <wildfly-camel.tag>1</wildfly-camel.tag>
+    <wildfly-camel.tag>DUMMY-TAG-0.0.0</wildfly-camel.tag>
     <wildfly-camel.fetch.scmUrl>1</wildfly-camel.fetch.scmUrl>
     <wildfly-camel.push.scmUrl>1</wildfly-camel.push.scmUrl>
     <wildfly-camel.buildCommand>1</wildfly-camel.buildCommand>
-    <apicurito.tag>1</apicurito.tag>
+    <apicurito.tag>DUMMY-TAG-0.0.0</apicurito.tag>
     <apicurito.fetch.scmUrl>1</apicurito.fetch.scmUrl>
     <apicurito.push.scmUrl>1</apicurito.push.scmUrl>
     <apicurito.buildCommand>1</apicurito.buildCommand>
-    <redhat-fuse.tag>1</redhat-fuse.tag>
+    <redhat-fuse.tag>DUMMY-TAG-0.0.0</redhat-fuse.tag>
     <redhat-fuse.fetch.scmUrl>1</redhat-fuse.fetch.scmUrl>
     <redhat-fuse.push.scmUrl>1</redhat-fuse.push.scmUrl>
     <redhat-fuse.buildCommand>1</redhat-fuse.buildCommand>
-    <fuse-apicurito-generator.tag>1</fuse-apicurito-generator.tag>
+    <fuse-apicurito-generator.tag>DUMMY-TAG-0.0.0</fuse-apicurito-generator.tag>
     <fuse-apicurito-generator.fetch.scmUrl>1</fuse-apicurito-generator.fetch.scmUrl>
     <fuse-apicurito-generator.push.scmUrl>1</fuse-apicurito-generator.push.scmUrl>
     <fuse-apicurito-generator.buildCommand>1</fuse-apicurito-generator.buildCommand>
-    <wildfly-camel-examples.tag>1</wildfly-camel-examples.tag>
+    <wildfly-camel-examples.tag>DUMMY-TAG-0.0.0</wildfly-camel-examples.tag>
     <wildfly-camel-examples.fetch.scmUrl>1</wildfly-camel-examples.fetch.scmUrl>
     <wildfly-camel-examples.push.scmUrl>1</wildfly-camel-examples.push.scmUrl>
     <wildfly-camel-examples.buildCommand>1</wildfly-camel-examples.buildCommand>
-    <fuse-eap.tag>1</fuse-eap.tag>
+    <fuse-eap.tag>DUMMY-TAG-0.0.0</fuse-eap.tag>
     <fuse-eap.fetch.scmUrl>1</fuse-eap.fetch.scmUrl>
     <fuse-eap.push.scmUrl>1</fuse-eap.push.scmUrl>
     <fuse-eap.buildCommand>1</fuse-eap.buildCommand>
-    <ipaas-quickstarts.tag>1</ipaas-quickstarts.tag>
+    <ipaas-quickstarts.tag>DUMMY-TAG-0.0.0</ipaas-quickstarts.tag>
     <ipaas-quickstarts.fetch.scmUrl>1</ipaas-quickstarts.fetch.scmUrl>
     <ipaas-quickstarts.push.scmUrl>1</ipaas-quickstarts.push.scmUrl>
     <ipaas-quickstarts.buildCommand>1</ipaas-quickstarts.buildCommand>
@@ -215,11 +215,11 @@
     <application-templates.buildCommand>1</application-templates.buildCommand>
 
     <!-- Syndesis project -->
-    <atlasmap.tag>1</atlasmap.tag>
+    <atlasmap.tag>DUMMY-TAG-0.0.0</atlasmap.tag>
     <atlasmap.fetch.scmUrl>1</atlasmap.fetch.scmUrl>
     <atlasmap.push.scmUrl>1</atlasmap.push.scmUrl>
     <atlasmap.buildCommand>1</atlasmap.buildCommand>
-    <syndesis.tag>1</syndesis.tag>
+    <syndesis.tag>DUMMY-TAG-0.0.0</syndesis.tag>
     <syndesis.fetch.scmUrl>1</syndesis.fetch.scmUrl>
     <syndesis.push.scmUrl>1</syndesis.push.scmUrl>
     <syndesis.buildCommand>1</syndesis.buildCommand>

--- a/src/main/resources/fusefis.yaml
+++ b/src/main/resources/fusefis.yaml
@@ -160,8 +160,9 @@ builds:
     #pushScmUrl: ${hawtio.push.scmUrl}
     #tag: ${hawtio.tag}
     #buildCommand: ${hawtio.buildCommand}
+    #cherrypick: true
   scmUrl: git+ssh://code.engineering.redhat.com/jboss-fuse/hawtio.git
-  scmRevision: hawtio-${version.hawtio}
+  scmRevision: hawtio-${version.hawtio}-redhat
   buildScript: >
     export REG=http://mwnodereg.hosts.mwqe.eng.bos.redhat.com:49160
     

--- a/src/main/resources/fusefis.yaml
+++ b/src/main/resources/fusefis.yaml
@@ -88,6 +88,8 @@ builds:
     - '-DdependencyExclusion.org.apache.abdera:*@*='
     - '-DdependencyExclusion.org.reactivestreams:*@*='
     - '-DdependencyOverride.org.bouncycastle:*@*='
+    - '-DdependencyExclusion.org.apache.kafka:*@*='
+
   dependencies:
   - cxf-3.1.11-${version.fuse.prefix}
   - karaf-4.2.0-${version.fuse.prefix}

--- a/src/main/resources/fusefis.yaml
+++ b/src/main/resources/fusefis.yaml
@@ -1,10 +1,10 @@
 product:
   name: Red Hat Fuse
   abbreviation: Fuse-and-FIS
-  stage: EA1
+  stage: ${build.stage}
   issueTrackerUrl: http://issues.jboss.org/browse/ENTESB
 version: ${version.fuse.prefix}
-milestone: Sprint30
+milestone: ${build.milestone}
 group: Fuse Standalone and FIS 7.2
 defaultBuildParameters:
   environmentId: 1

--- a/src/main/resources/fusefis.yaml
+++ b/src/main/resources/fusefis.yaml
@@ -146,9 +146,8 @@ builds:
   customPmeParameters:
     - '-DprojectMetaSkip=true'
     - '-Drepo-reporting-removal=true'
-    - '-DgroovyScript=org.jboss.fuse.pom-manipulation:manifest-version-update:groovy:1.0.6.redhat-00001'
     - '-DgroovyManipulationPrecedence=FIRST'
-    - '-DgroovyScripts=org.jboss.fuse.pom-manipulation:manifest-version-update:groovy:1.0.7.redhat-00001'
+    - '-DgroovyScripts=org.jboss.fuse.pom-manipulation:manifest-version-update:groovy:${version.pom-manipulation}'
 
   dependencies:
   - camel-2.21.0-${version.fuse.prefix}
@@ -181,7 +180,7 @@ builds:
   customPmeParameters:  
     - '-DdependencyOverride.com.fasterxml.jackson.core:*@*='
     - '-DprojectMetaSkip=true'
-    - '-DgroovyScripts=org.jboss.fuse.pom-manipulation:yarn-config-groovy:groovy:1.0.6.redhat-00001'
+    - '-DgroovyScripts=org.jboss.fuse.pom-manipulation:yarn-config-groovy:groovy:${version.pom-manipulation}'
     - '-DgroovyManipulationPrecedence=FIRST'
   dependencies:
   - camel-2.21.0-${version.fuse.prefix}
@@ -388,7 +387,7 @@ builds:
   scmUrl: git+ssh://code.engineering.redhat.com/fabric8io-fabric8.git
   scmRevision: fabric8v2-${version.fabric8}
   customPmeParameters:
-    - '-DprofileInjection=org.jboss.fuse.pom-manipulation:fabric8-profiles:1.0.4.redhat-1'
+    - '-DprofileInjection=org.jboss.fuse.pom-manipulation:fabric8-profiles:${version.pom-manipulation}'
     - '-DprojectMetaSkip=true'
     - '-DdependencyExclusion.com.fasterxml.jackson.core:*@*='
     - '-DdependencyExclusion.com.fasterxml.jackson.jaxrs:*@*='

--- a/src/main/resources/fusefis.yaml
+++ b/src/main/resources/fusefis.yaml
@@ -418,15 +418,19 @@ builds:
     #buildCommand: ${narayana-spring-boot.buildCommand}
   project: jboss-fuse/narayana-spring-boot
   scmUrl: git+ssh://code.engineering.redhat.com/jboss-fuse/narayana-spring-boot.git
-  scmRevision: narayana-spring-boot-1.0.2.fuse-710001
+  scmRevision: ${narayana-spring-boot.tag}
   buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false -P clean deploy -DskipClean'
   dependencies:
     - redhat-fuse-${version.fuse.prefix}
 
-- name: spring-boot-camel-xa-quickstart-1.0.0-${version.fuse.prefix}
+- name: spring-boot-camel-xa-1.0.0-${version.fuse.prefix}
+    #fetchScmUrl: ${spring-boot-camel-xa.fetch.scmUrl}
+    #pushScmUrl: ${spring-boot-camel-xa.push.scmUrl}
+    #tag: ${spring-boot-camel-xa.tag}
+    #buildCommand: ${spring-boot-camel-xa.buildCommand}
   project: jboss-fuse/spring-boot-camel-xa
   scmUrl: git+ssh://code.engineering.redhat.com/jboss-fuse/spring-boot-camel-xa.git
-  scmRevision: spring-boot-camel-xa-quickstart-1.0.0.fuse-710001
+  scmRevision: ${spring-boot-camel-xa.tag}
   buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false -P clean deploy -DskipClean'
   dependencies:
     - redhat-fuse-${version.fuse.prefix}

--- a/src/main/resources/fusefis.yaml
+++ b/src/main/resources/fusefis.yaml
@@ -375,7 +375,9 @@ builds:
   scmRevision: ipaas-quickstarts-${version.ipaas.quickstarts}-redhat
   buildScript: >
     mv repolist.txt repolist.txt.orig
+
     sed 's/https:\/\/github\.com/https:\/\/code.engineering.redhat.com\/gerrit/g' repolist.txt.orig > repolist.txt
+
     mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false -Dquickstart.git.repos=repolist.txt -Dgpg.skip -Prelease clean deploy
   dependencies:
   - fabric8v2-3.0.11-${version.fuse.prefix} 
@@ -413,6 +415,35 @@ builds:
   buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false -P clean
     deploy'
   scmRevision: kubernetes-model-${version.kubernetes.model}
+
+- name: apicurito-1.0.0-${version.fuse.prefix}
+  project: jboss-fuse/apicurito
+    #fetchScmUrl: ${apicurito.fetch.scmUrl}
+    #pushScmUrl: ${apicurito.push.scmUrl}
+    #tag: ${apicurito.tag}
+    #buildCommand: ${apicurito.buildCommand}
+  scmUrl: git+ssh://code.engineering.redhat.com/jboss-fuse/apicurito.git
+  scmRevision: ${apicurito.tag}
+  buildScript: >
+    export REG=http://mwnodereg.hosts.mwqe.eng.bos.redhat.com:49223
+
+    sed -i 's#https://registry.yarnpkg.com/#http://mwnodereg.hosts.mwqe.eng.bos.redhat.com:49223/#g' ui/yarn.lock
+
+    sed -i 's#https:#http:#g' ui/yarn.lock
+
+    mvn  -e -V -B  -DnpmRegistryURL2=$REG  -Dgpg.skip=true -DnpmDownloadRoot=http://download-node-02.eng.bos.redhat.com/rcm-guest/staging/fuse/npm/dist/npm/ -DyarnRegistry=$REG  -DskipTests=true -DyarnDownloadRoot=http://download-node-02.eng.bos.redhat.com/rcm-guest/staging/fuse/yarn/dist/ -DnodeDownloadRoot=http://download-node-02.eng.bos.redhat.com/rcm-guest/staging/fuse/npm/dist/   -DyarnInheritsProxyConfigFromMaven=false -Dyarn.install.args='--network-concurrency 30 --child-concurrency 2 --no-progress' clean deploy
+
+- name:  fuse-apicurito-generator-1.0.0-${version.fuse.prefix}
+  project: jboss-fuse/fuse-apicurito-generator
+    #fetchScmUrl: ${fuse-apicurito-generator.fetch.scmUrl}
+    #pushScmUrl: ${fuse-apicurito-generator.push.scmUrl}
+    #tag: ${fuse-apicurito-generator.tag}
+    #buildCommand: ${fuse-apicurito-generator.buildCommand}
+  scmUrl: git+ssh://code.engineering.redhat.com/jboss-fuse/fuse-apicurito-generator.git
+  scmRevision: ${fuse-apicurito-generator.tag}
+  buildScript: mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false -P clean deploy -DskipClean
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
 
 - name: narayana-spring-boot-quickstart-1.0.2-${version.fuse.prefix}
     #fetchScmUrl: ${narayana-spring-boot.fetch.scmUrl}


### PR DESCRIPTION
Various fixes that where needed for CR1 builds

1. Add "Build info" (milestone and build stage properties) via pom.xml [24247ef]
2. Add singleton version for pom-manipulation scripts [4fae989]
3. Fix spring-boot-camel-xa and narayana-springboot [e2c1c6e]
4. ENTESB-9736 [4fae989]
5. Hawtio redhat branch [ac0466a]
6. Add apicurito build configs [a654db0]


@cunningt 1, 3 & 6 probably need to be hooked up to the pipeline, hopefully I got the naming scheme right