### PR TITLE
ENTESB-10331: Added a exclusion to enforce javax.ws.rs to be ignored …

### DIFF
--- a/src/main/resources/fusefis.yaml
+++ b/src/main/resources/fusefis.yaml
@@ -476,6 +476,7 @@ builds:
     - '-DdependencyExclusion.com.fasterxml.jackson.dataformat:*@*='
     - '-DdependencyExclusion.com.fasterxml.jackson.datatype:*@*='
     - '-DdependencyExclusion.org.glassfish.web:*@*='
+    - '-DdependencyExclusion.javax.ws.rs:*@*=2.1.1'
   dependencies:
   - docker-maven-plugin-0.23.0-${version.fuse.prefix}
   - spring-cloud-kubernetes-0.1.6-${version.fuse.prefix}

--- a/src/main/resources/fusefis.yaml
+++ b/src/main/resources/fusefis.yaml
@@ -477,6 +477,7 @@ builds:
     - '-DdependencyExclusion.com.fasterxml.jackson.datatype:*@*='
     - '-DdependencyExclusion.org.glassfish.web:*@*='
     - '-DdependencyExclusion.javax.ws.rs:*@*=2.1.1'
+    - '-DdependencyExclusion.org.apache.activemq:*@*='
   dependencies:
   - docker-maven-plugin-0.23.0-${version.fuse.prefix}
   - spring-cloud-kubernetes-0.1.6-${version.fuse.prefix}

--- a/src/main/resources/fusefis.yaml
+++ b/src/main/resources/fusefis.yaml
@@ -80,7 +80,7 @@ builds:
   externalScmUrl: ssh://git@github.com/jboss-fuse/cxf.git
   scmRevision: cxf-${version.cxf}
   customPmeParameters:
-    - '-DdependencyOverride.javax.ws.rs:*@*=2.1.1'
+    - '-DdependencyExclusion.javax.ws.rs:*@*=2.1.1'
     - '-DdependencyOverride.javax.xml.bind:*@*='
     - '-DdependencyOverride.org.codehaus.woodstox:*@*='
     - '-DdependencyOverride.org.apache.abdera:*@*='


### PR DESCRIPTION
Tries to prevent PME from manipulating javax.ws.rs in CXF, which is causing trouble due to invalid OSGI manifests. 