### PR TITLE
Fix overwriting of generated artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
-# fuse-build-yaml
-Fuse Build YAML generation
+# Fuse Build Yaml
+
+This project is used to generate the YAML file that is consumed by [PiG](https://gitlab.cee.redhat.com/tcunning/piglet)
+to generate the configuration and drive the PNC builds.
+
+## Usage
+
+This project supports the modularized format of the Fuse project that started with version
+7.5. As such, it is capable of generating different yaml files required by each module or
+product. The generated files can be distinguished by their classifiers, which match the
+Maven profile used to generate the files.
+
+The following Maven profiles are currently implemented:
+
+* core-sb1: for Fuse Core modules with Spring Boot v1
+* dv: for the Data Virtualization project
+* fusefis: for the legacy Fuse FIS project format (likely to be removed)
+* ipaas: for iPaaS
+* springboot2: for Fuse components built with Spring Boot v2 support.
+
+A sample generation of the files from this project, for the `core-sb1` profile looks like this:
+
+```mvn -Pcore-sb1 -Dbuild.stage=DR1 -Dbuild.milestone=DR1 -DaltDeploymentRepository=local-snapshots::default::http://nexus:8081/artifactory/snaphots clean deploy```
+
+This would generate the following set of files:
+
+```fuse-build-yaml-7.5.0.redhat-SNAPSHOT-core-sb1-deptree.html
+fuse-build-yaml-7.5.0.redhat-SNAPSHOT-core-sb1-modified-yaml.yaml
+fuse-build-yaml-7.5.0.redhat-SNAPSHOT-core-sb1-staging-deptree.html
+fuse-build-yaml-7.5.0.redhat-SNAPSHOT-core-sb1-staging-modified-yaml.yaml
+fuse-build-yaml-7.5.0.redhat-SNAPSHOT-core-sb1-staging-yaml.yaml
+fuse-build-yaml-7.5.0.redhat-SNAPSHOT-core-sb1-yaml.yaml
+```
+
+Similarly, using a different profile, such as `ipaas`, would generate the files specifically for that profile:
+
+```mvn -Pipaas -Dbuild.stage=DR1 -Dbuild.milestone=DR1 -DaltDeploymentRepository=local-snapshots::default::http://nexus:8081/artifactory/snaphots clean deploy```
+
+```fuse-build-yaml-7.5.0.redhat-SNAPSHOT-ipaas-deptree.html
+fuse-build-yaml-7.5.0.redhat-SNAPSHOT-ipaas-modified-yaml.yaml
+fuse-build-yaml-7.5.0.redhat-SNAPSHOT-ipaas-staging-deptree.html
+fuse-build-yaml-7.5.0.redhat-SNAPSHOT-ipaas-staging-modified-yaml.yaml
+fuse-build-yaml-7.5.0.redhat-SNAPSHOT-ipaas-staging-yaml.yaml
+fuse-build-yaml-7.5.0.redhat-SNAPSHOT-ipaas-yaml.yaml
+```
+
+There is no default profile and not providing one will result in no file to be generated.
+
+Please also make sure to inform the appropriate value (ie.: DR1, DR2, CR1, CR2, etc) for
+build.milestone and build.stage properties. These are used to fill certain parameters in
+the YAML files. Among other things, they define the current milestone on PNC and are used
+in the title of the build groups.

--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,16 @@
       </resource>
     </resources>
 
+    <pluginManagement>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <version>3.0.0</version>
+          </plugin>
+        </plugins>
+      </pluginManagement>
+
     <plugins>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -349,67 +359,6 @@
         </dependencies>
     </plugin>
 
-    <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <id>attach-artifacts</id>
-            <phase>generate-resources</phase>
-            <goals>
-              <goal>attach-artifact</goal>
-            </goals>
-            <configuration>
-              <artifacts>
-                <!-- Fuse and FIS Original (template) -->
-                <artifact>
-                  <file>target/extra-resources/${yaml.name}.yaml</file>
-                  <type>yaml</type>
-                  <classifier>fuse-fis-yaml</classifier>
-                </artifact>
-                <!-- Fuse and FIS Fixed -->
-                <artifact>
-                  <file>target/extra-resources/${yaml.name}.yaml.modified</file>
-                  <type>yaml</type>
-                  <classifier>fuse-fis-modified-yaml</classifier>
-                </artifact>
-                <!-- Fuse and FIS Deptree -->
-                <artifact>
-                  <file>target/extra-resources/${yaml.name}.yaml.html</file>
-                  <type>html</type>
-                  <classifier>fuse-fis-deptree</classifier>
-                </artifact>
-
-                <artifact>
-                  <file>target/extra-resources/${yaml.name}-staging.yaml</file>
-                  <type>yaml</type>
-                  <classifier>staging-yaml</classifier>
-                </artifact>
-                <!-- Fuse and FIS Fixed -->
-                <artifact>
-                  <file>target/extra-resources/${yaml.name}-staging.yaml.modified</file>
-                  <type>yaml</type>
-                  <classifier>staging-modified-yaml</classifier>
-                </artifact>
-                <!-- Fuse and FIS Deptree -->
-                <artifact>
-                  <file>target/extra-resources/${yaml.name}-staging.yaml.html</file>
-                  <type>html</type>
-                  <classifier>staging-deptree</classifier>
-                </artifact>
-
-                <artifact>
-                  <file>target/extra-resources/release_fis_quickstarts.sh</file>
-                  <type>sh</type>
-                  <classifier>sh</classifier>
-                </artifact>
-              </artifacts>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
       <plugin>
         <groupId>com.coderplus.maven.plugins</groupId>
         <artifactId>copy-rename-maven-plugin</artifactId>
@@ -478,4 +427,347 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+      <profile>
+        <id>fusefis</id>
+        <activation>
+          <activeByDefault>false</activeByDefault>
+        </activation>
+        <properties>
+          <yaml.name>fusefis</yaml.name>
+        </properties>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>build-helper-maven-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>attach-artifacts</id>
+                  <phase>generate-resources</phase>
+                  <goals>
+                    <goal>attach-artifact</goal>
+                  </goals>
+                  <configuration>
+                    <artifacts>
+                      <!-- Fuse and FIS Original (template) -->
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}.yaml</file>
+                        <type>yaml</type>
+                        <classifier>fuse-fis-yaml</classifier>
+                      </artifact>
+                      <!-- Fuse and FIS Fixed -->
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}.yaml.modified</file>
+                        <type>yaml</type>
+                        <classifier>fuse-fis-modified-yaml</classifier>
+                      </artifact>
+                      <!-- Fuse and FIS Deptree -->
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}.yaml.html</file>
+                        <type>html</type>
+                        <classifier>fuse-fis-deptree</classifier>
+                      </artifact>
+
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}-staging.yaml</file>
+                        <type>yaml</type>
+                        <classifier>staging-yaml</classifier>
+                      </artifact>
+                      <!-- Fuse and FIS Fixed -->
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}-staging.yaml.modified</file>
+                        <type>yaml</type>
+                        <classifier>staging-modified-yaml</classifier>
+                      </artifact>
+                      <!-- Fuse and FIS Deptree -->
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}-staging.yaml.html</file>
+                        <type>html</type>
+                        <classifier>staging-deptree</classifier>
+                      </artifact>
+
+                      <artifact>
+                        <file>target/extra-resources/release_fis_quickstarts.sh</file>
+                        <type>sh</type>
+                        <classifier>sh</classifier>
+                      </artifact>
+                    </artifacts>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
+
+      <profile>
+        <id>core-sb1</id>
+        <activation>
+          <activeByDefault>false</activeByDefault>
+        </activation>
+        <properties>
+          <yaml.name>core-sb1</yaml.name>
+        </properties>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>build-helper-maven-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>attach-artifacts</id>
+                  <phase>generate-resources</phase>
+                  <goals>
+                    <goal>attach-artifact</goal>
+                  </goals>
+                  <configuration>
+                    <artifacts>
+                      <!-- Fuse and FIS Original (template) -->
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}.yaml</file>
+                        <type>yaml</type>
+                        <classifier>${yaml.name}-yaml</classifier>
+                      </artifact>
+                      <!-- Fuse and FIS Fixed -->
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}.yaml.modified</file>
+                        <type>yaml</type>
+                        <classifier>${yaml.name}-modified-yaml</classifier>
+                      </artifact>
+                      <!-- Fuse and FIS Deptree -->
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}.yaml.html</file>
+                        <type>html</type>
+                        <classifier>${yaml.name}-deptree</classifier>
+                      </artifact>
+
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}-staging.yaml</file>
+                        <type>yaml</type>
+                        <classifier>${yaml.name}-staging-yaml</classifier>
+                      </artifact>
+                      <!-- Fuse and FIS Fixed -->
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}-staging.yaml.modified</file>
+                        <type>yaml</type>
+                        <classifier>${yaml.name}-staging-modified-yaml</classifier>
+                      </artifact>
+                      <!-- Fuse and FIS Deptree -->
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}-staging.yaml.html</file>
+                        <type>html</type>
+                        <classifier>${yaml.name}-staging-deptree</classifier>
+                      </artifact>
+                    </artifacts>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
+
+      <profile>
+        <id>dv</id>
+        <activation>
+          <activeByDefault>false</activeByDefault>
+        </activation>
+        <properties>
+          <yaml.name>dv</yaml.name>
+        </properties>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>build-helper-maven-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>attach-artifacts</id>
+                  <phase>generate-resources</phase>
+                  <goals>
+                    <goal>attach-artifact</goal>
+                  </goals>
+                  <configuration>
+                    <artifacts>
+                      <!-- Fuse and FIS Original (template) -->
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}.yaml</file>
+                        <type>yaml</type>
+                        <classifier>${yaml.name}-yaml</classifier>
+                      </artifact>
+                      <!-- Fuse and FIS Fixed -->
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}.yaml.modified</file>
+                        <type>yaml</type>
+                        <classifier>${yaml.name}-modified-yaml</classifier>
+                      </artifact>
+                      <!-- Fuse and FIS Deptree -->
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}.yaml.html</file>
+                        <type>html</type>
+                        <classifier>${yaml.name}-deptree</classifier>
+                      </artifact>
+
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}-staging.yaml</file>
+                        <type>yaml</type>
+                        <classifier>${yaml.name}-staging-yaml</classifier>
+                      </artifact>
+                      <!-- Fuse and FIS Fixed -->
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}-staging.yaml.modified</file>
+                        <type>yaml</type>
+                        <classifier>${yaml.name}-staging-modified-yaml</classifier>
+                      </artifact>
+                      <!-- Fuse and FIS Deptree -->
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}-staging.yaml.html</file>
+                        <type>html</type>
+                        <classifier>${yaml.name}-staging-deptree</classifier>
+                      </artifact>
+                    </artifacts>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
+
+      <profile>
+        <id>ipaas</id>
+        <activation>
+          <activeByDefault>false</activeByDefault>
+        </activation>
+        <properties>
+          <yaml.name>ipaas</yaml.name>
+        </properties>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>build-helper-maven-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>attach-artifacts</id>
+                  <phase>generate-resources</phase>
+                  <goals>
+                    <goal>attach-artifact</goal>
+                  </goals>
+                  <configuration>
+                    <artifacts>
+                      <!-- Fuse and FIS Original (template) -->
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}.yaml</file>
+                        <type>yaml</type>
+                        <classifier>${yaml.name}-yaml</classifier>
+                      </artifact>
+                      <!-- Fuse and FIS Fixed -->
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}.yaml.modified</file>
+                        <type>yaml</type>
+                        <classifier>${yaml.name}-modified-yaml</classifier>
+                      </artifact>
+                      <!-- Fuse and FIS Deptree -->
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}.yaml.html</file>
+                        <type>html</type>
+                        <classifier>${yaml.name}-deptree</classifier>
+                      </artifact>
+
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}-staging.yaml</file>
+                        <type>yaml</type>
+                        <classifier>${yaml.name}-staging-yaml</classifier>
+                      </artifact>
+                      <!-- Fuse and FIS Fixed -->
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}-staging.yaml.modified</file>
+                        <type>yaml</type>
+                        <classifier>${yaml.name}-staging-modified-yaml</classifier>
+                      </artifact>
+                      <!-- Fuse and FIS Deptree -->
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}-staging.yaml.html</file>
+                        <type>html</type>
+                        <classifier>${yaml.name}-staging-deptree</classifier>
+                      </artifact>
+                    </artifacts>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
+
+      <profile>
+        <id>springboot2</id>
+        <activation>
+          <activeByDefault>false</activeByDefault>
+        </activation>
+        <properties>
+          <yaml.name>springboot2</yaml.name>
+        </properties>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>build-helper-maven-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>attach-artifacts</id>
+                  <phase>generate-resources</phase>
+                  <goals>
+                    <goal>attach-artifact</goal>
+                  </goals>
+                  <configuration>
+                    <artifacts>
+                      <!-- Fuse and FIS Original (template) -->
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}.yaml</file>
+                        <type>yaml</type>
+                        <classifier>${yaml.name}-yaml</classifier>
+                      </artifact>
+                      <!-- Fuse and FIS Fixed -->
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}.yaml.modified</file>
+                        <type>yaml</type>
+                        <classifier>${yaml.name}-modified-yaml</classifier>
+                      </artifact>
+                      <!-- Fuse and FIS Deptree -->
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}.yaml.html</file>
+                        <type>html</type>
+                        <classifier>${yaml.name}-deptree</classifier>
+                      </artifact>
+
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}-staging.yaml</file>
+                        <type>yaml</type>
+                        <classifier>${yaml.name}-staging-yaml</classifier>
+                      </artifact>
+                      <!-- Fuse and FIS Fixed -->
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}-staging.yaml.modified</file>
+                        <type>yaml</type>
+                        <classifier>${yaml.name}-staging-modified-yaml</classifier>
+                      </artifact>
+                      <!-- Fuse and FIS Deptree -->
+                      <artifact>
+                        <file>target/extra-resources/${yaml.name}-staging.yaml.html</file>
+                        <type>html</type>
+                        <classifier>${yaml.name}-staging-deptree</classifier>
+                      </artifact>
+                    </artifacts>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
I noticed that running the project with maven causes it to save the files always with the same name. This can cause trouble when running multiple projects at the same time or when sequentially deploying the project, since the contents of the generated yaml would always be:

```fuse-build-yaml-7.5.0.redhat-SNAPSHOT-fuse-fis-deptree.html
fuse-build-yaml-7.5.0.redhat-SNAPSHOT-fuse-fis-modified-yaml.yaml
fuse-build-yaml-7.5.0.redhat-SNAPSHOT-fuse-fis-yaml.yaml
fuse-build-yaml-7.5.0.redhat-SNAPSHOT.pom
fuse-build-yaml-7.5.0.redhat-SNAPSHOT-sh.sh
fuse-build-yaml-7.5.0.redhat-SNAPSHOT-staging-deptree.html
fuse-build-yaml-7.5.0.redhat-SNAPSHOT-staging-modified-yaml.yaml
fuse-build-yaml-7.5.0.redhat-SNAPSHOT-staging-yaml.yaml
```

This PR introduces a set of profiles that can be used to generate the files according to the set of components or products it relates to. For example, using the core-sb1 profile, generates these files:


```fuse-build-yaml-7.5.0.redhat-SNAPSHOT-core-sb1-deptree.html
fuse-build-yaml-7.5.0.redhat-SNAPSHOT-core-sb1-modified-yaml.yaml
fuse-build-yaml-7.5.0.redhat-SNAPSHOT-core-sb1-staging-deptree.html
fuse-build-yaml-7.5.0.redhat-SNAPSHOT-core-sb1-staging-modified-yaml.yaml
fuse-build-yaml-7.5.0.redhat-SNAPSHOT-core-sb1-staging-yaml.yaml
fuse-build-yaml-7.5.0.redhat-SNAPSHOT-core-sb1-yaml.yaml
```

It also introduces some basic documentation explaining the new behavior
