### PR TITLE
Upgrades Core SB1 to use Maven 3.5.2 on PNC

### DIFF
--- a/src/main/resources/core-sb1.yaml
+++ b/src/main/resources/core-sb1.yaml
@@ -7,7 +7,7 @@ version: ${version.fuse.prefix}
 milestone: ${build.milestone}
 group: Red Hat Fuse - Core SB1 ${version.fuse.project} ${build.milestone}
 defaultBuildParameters:
-  environmentId: 1
+  environmentId: 8
   buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean
     deploy'
 


### PR DESCRIPTION
From PNC CLI (pnc list-environments | jq .):

```{
    "attributes": {
      "JDK": "1.8.0",
      "MAVEN": "3.5.2",
      "OS": "Linux"
    },
    "deprecated": false,
    "description": "OpenJDK 1.8.0; Mvn 3.5.2",
    "id": 8,
    "image_repository_url": "docker-registry-default.cloud.registry.upshift.redhat.com",
    "name": "OpenJDK 1.8.0; Mvn 3.5.2",
    "system_image_id": "newcastle/builder-rhel-7-j8-mvn3.5.2:latest",
    "system_image_repository_url": "docker-registry-default.cloud.registry.upshift.redhat.com",
    "system_image_type": "DOCKER_IMAGE"
  },```