### PR TITLE
Add quickstarts to the PME build so we can more easily automate ipaas-quickstarts/application-templates

### DIFF
--- a/pme-disabled.properties
+++ b/pme-disabled.properties
@@ -27,6 +27,20 @@ apicurito.pme.options=-DdependencyOverride.*:*@*=
 fuse-apicurito-generator.pme.options=-DdependencyOverride.*:*@*=
 narayana-spring-boot-quickstart.pme.options=-DdependencyOverride.*:*@*=
 spring-boot-camel-xa.pme.options=-DdependencyOverride.*:*@*=
+karaf-camel-amq.pme.options=-DdependencyOverride.*:*@*=
+karaf-camel-log.pme.options=-DdependencyOverride.*:*@*=
+karaf-camel-rest-sql.pme.options=-DdependencyOverride.*:*@*=
+karaf-cxf-rest.pme.options=-DdependencyOverride.*:*@*=
+spring-boot-camel.pme.options=-DdependencyOverride.*:*@*=
+spring-boot-camel-amq.pme.options=-DdependencyOverride.*:*@*=
+spring-boot-camel-config.pme.options=-DdependencyOverride.*:*@*=
+spring-boot-camel-drools.pme.options=-DdependencyOverride.*:*@*=
+spring-boot-camel-infinispan=-DdependencyOverride.*:*@*=
+spring-boot-camel-rest-sql=-DdependencyOverride.*:*@*=
+spring-boot-camel-rest-3scale=-DdependencyOverride.*:*@*=
+spring-boot-camel-xml=-DdependencyOverride.*:*@*=
+spring-boot-cxf-jaxrs=-DdependencyOverride.*:*@*=
+spring-boot-cxf-jaxws=-DdependencyOverride.*:*@*=
 camel-k-runtime.pme.options=-DrepoReportingRemoval=true -DenforceProjectVersion=off -DexcludedScopes=compile,test,provided,runtime,system -DprojectMetaSkip=true -DdependencyOverride.*:*@*=
 teiid.build.options=-DrepoReportingRemoval=true -DenforceProjectVersion=off -DexcludedScopes=compile,test,provided,runtime,system -DprojectMetaSkip=true -DdependencyOverride.*:*@*=
 teiid-spring-boot.build.options=-DrepoReportingRemoval=true -DenforceProjectVersion=off -DexcludedScopes=compile,test,provided,runtime,system -DprojectMetaSkip=true -DdependencyOverride.*:*@*=

--- a/pme.properties
+++ b/pme.properties
@@ -28,6 +28,20 @@ fuse-apicurito-generator.pme.options=-DscanActiveProfiles=true
 narayana-spring-boot.pme.options=-DscanActiveProfiles=true -DdependencyOverride.com.fasterxml.jackson.module:*@*= -DdependencyOverride.com.fasterxml.jackson.jaxrs:*@*= -DdependencyOverride.com.fasterxml.jackson.core:*@*= -DdependencyOverride.com.fasterxml.jackson.jaxrs:*@*= -DdependencyOverride.com.fasterxml.jackson.dataformat:*@*= -DdependencyOverride.com.fasterxml.jackson.datatype:*@*=
 narayana-spring-boot-quickstart.pme.options=-DscanActiveProfiles=true -DdependencyOverride.com.fasterxml.jackson.module:*@*= -DdependencyOverride.com.fasterxml.jackson.jaxrs:*@*= -DdependencyOverride.com.fasterxml.jackson.core:*@*= -DdependencyOverride.com.fasterxml.jackson.jaxrs:*@*= -DdependencyOverride.com.fasterxml.jackson.dataformat:*@*= -DdependencyOverride.com.fasterxml.jackson.datatype:*@*=
 spring-boot-camel-xa.pme.options=-DscanActiveProfiles=true
+karaf-camel-amq.pme.options=-DscanActiveProfiles=true
+karaf-camel-log.pme.options=-DscanActiveProfiles=true
+karaf-camel-rest-sql.pme.options=-DscanActiveProfiles=true
+karaf-cxf-rest.pme.options=-DscanActiveProfiles=true
+spring-boot-camel.pme.options=-DscanActiveProfiles=true
+spring-boot-camel-amq.pme.options=-DscanActiveProfiles=true
+spring-boot-camel-config.pme.options=-DscanActiveProfiles=true
+spring-boot-camel-drools.pme.options=-DscanActiveProfiles=true
+spring-boot-camel-infinispan=-DscanActiveProfiles=true
+spring-boot-camel-rest-sql=-DscanActiveProfiles=true
+spring-boot-camel-rest-3scale=-DscanActiveProfiles=true
+spring-boot-camel-xml=-DscanActiveProfiles=true
+spring-boot-cxf-jaxrs=-DscanActiveProfiles=true
+spring-boot-cxf-jaxws=-DscanActiveProfiles=true
 camel-k-runtime.pme.options=-DscanActiveProfiles=true -DdependencyExclusion.javax.ws.rs:*@*= -DdependencyOverride.com.fasterxml.jackson.dataformat:*@*= -DdependencyOverride.com.fasterxml.jackson.core:*@*= -DdependencyOverride.com.fasterxml.jackson.datatype:*@*=
 #
 teiid.pme.options=-DdependencyOverride.com.fasterxml.jackson.core:*@*=2.9.9 -DdependencyOverride.com.fasterxml.jackson.datatype:*@*=2.9.9  -DdependencyOverride.com.fasterxml.jackson.dataformat:*@*=2.9.9 -DdependencyOverride.wsdl4j:wsdl4j@*=1.6.3 -DdependencyOverride.org.jboss.logging:jboss-logging@*=3.4.0.Final -DdependencyOverride.commons-configuration:*@*=1.6 -DdependencyOverride.com.io7m.xom:*@*=1.2.10 -DdependencyExclusion.com.sun.xml.bind:*@*= -DdependencyOverride.org.ow2.asm:*@*= -DprojectMetaSkip=true

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
     <spring-boot-camel-drools.version>1.0.0.fuse-710004</spring-boot-camel-drools.version>
     <spring-boot-camel-infinispan.version>1.0.0.fuse-710004</spring-boot-camel-infinispan.version>
     <spring-boot-camel-rest-sql.version>1.0.0.fuse-710004</spring-boot-camel-rest-sql.version>
+    <spring-boot-camel-rest-3scale.version>1.0.0.fuse-710004</spring-boot-camel-rest-3scale.version>
     <spring-boot-camel-teiid.version>1.0.0.fuse-710004</spring-boot-camel-teiid.version>
     <spring-boot-camel-xml.version>1.0.0.fuse-710004</spring-boot-camel-xml.version>
     <spring-boot-cxf-jaxrs.version>1.0.0.fuse-710004</spring-boot-cxf-jaxrs.version>

--- a/src/main/resources/quickstarts.yaml
+++ b/src/main/resources/quickstarts.yaml
@@ -54,6 +54,164 @@ builds:
     - redhat-fuse-${version.fuse.prefix}
     - narayana-spring-boot-quickstart-1.0.2-${version.fuse.prefix}
 
+- name: karaf-camel-amq-1.0.0-${version.fuse.prefix}
+    #fetchScmUrl: ${spring-boot-camel-xa.fetch.scmUrl}
+    #pushScmUrl: ${spring-boot-camel-xa.push.scmUrl}
+    #tag: spring-boot-camel-xa-${spring-boot-camel-xa.version}
+    #buildCommand: ${spring-boot-camel-xa.buildCommand}
+  project: fabric8-quickstarts/karaf-camel-amq
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/karaf-camel-amq.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/karaf-camel-amq.git
+  scmRevision: karaf-camel-amq-${karaf-camel-amq.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${karaf-camel-amq.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: karaf-camel-log-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/karaf-camel-log
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/karaf-camel-log.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/karaf-camel-log.git
+  scmRevision: karaf-camel-log-${karaf-camel-log.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${karaf-camel-log.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: karaf-camel-rest-sql-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/karaf-camel-rest-sql
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/karaf-camel-rest-sql.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/karaf-camel-rest-sql.git
+  scmRevision: karaf-camel-rest-sql-${karaf-camel-rest-sql.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${karaf-camel-rest-sql.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: karaf-cxf-rest-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/karaf-cxf-rest
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/karaf-cxf-rest.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/karaf-cxf-rest.git
+  scmRevision: karaf-cxf-rest-${karaf-cxf-rest.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${karaf-cxf-rest.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: spring-boot-camel-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/spring-boot-camel
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/spring-boot-camel.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/spring-boot-camel.git
+  scmRevision: spring-boot-camel-${spring-boot-camel.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${spring-boot-camel.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: spring-boot-camel-amq-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/spring-boot-camel-amq
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/spring-boot-camel-amq.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/spring-boot-camel-amq.git
+  scmRevision: spring-boot-camel-amq-${spring-boot-camel-amq.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${spring-boot-camel-amq.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: spring-boot-camel-config-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/spring-boot-camel-config
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/sspring-boot-camel-config.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/spring-boot-camel-config.git
+  scmRevision: spring-boot-camel-config-${spring-boot-camel-config.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${spring-boot-camel-config.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: spring-boot-camel-drools-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/spring-boot-camel-drools
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/spring-boot-camel-drools.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/spring-boot-camel-drools.git
+  scmRevision: spring-boot-camel-config-${spring-boot-camel-drools.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${spring-boot-camel-drools.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: spring-boot-camel-infinispan-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/spring-boot-camel-infinispan
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/spring-boot-camel-infinispan.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/spring-boot-camel-infinispan.git
+  scmRevision: spring-boot-camel-config-${spring-boot-camel-infinispan.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${spring-boot-camel-infinispan.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: spring-boot-camel-rest-sql-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/spring-boot-camel-rest-sql
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/spring-boot-camel-rest-sql.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/spring-boot-camel-rest-sql.git
+  scmRevision: spring-boot-camel-config-${spring-boot-camel-rest-sql.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${spring-boot-camel-rest-sql.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: spring-boot-camel-rest-3scale-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/spring-boot-camel-rest-3scale
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/spring-boot-camel-rest-3scale.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/spring-boot-camel-rest-3scale.git
+  scmRevision: spring-boot-camel-config-${spring-boot-camel-rest-3scale.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${spring-boot-camel-rest-3scale.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: spring-boot-camel-xml-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/spring-boot-camel-xml
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/spring-boot-camel-xml.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/spring-boot-camel-xml.git
+  scmRevision: spring-boot-camel-config-${spring-boot-camel-xml.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${spring-boot-camel-xml.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: spring-boot-cxf-jaxrs-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/spring-boot-cxf-jaxrs
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/spring-boot-cxf-jaxrs.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/spring-boot-cxf-jaxrs.git
+  scmRevision: spring-boot-camel-config-${spring-boot-cxf-jaxrs.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${spring-boot-cxf-jaxrs.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: spring-boot-cxf-jaxws-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/spring-boot-cxf-jaxws
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/spring-boot-cxf-jaxws.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/spring-boot-cxf-jaxws.git
+  scmRevision: spring-boot-camel-config-${spring-boot-cxf-jaxws.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${spring-boot-cxf-jaxws.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
 - name:  fuse-apicurito-generator-1.0.0-${version.fuse.prefix}
   project: jboss-fuse/fuse-apicurito-generator
     #fetchScmUrl: ${fuse-apicurito-generator.fetch.scmUrl}

--- a/src/main/resources/springboot2.yaml
+++ b/src/main/resources/springboot2.yaml
@@ -203,6 +203,176 @@ builds:
   - fabric8v2-3.0.11.sb2-${version.fuse.prefix}
   - fabric8-maven-plugin-sb2-3.5.42-${version.fuse.prefix}
 
+- name: spring-boot-camel-xa-sb2-1.0.0-${version.fuse.prefix}
+    #fetchScmUrl: ${spring-boot-camel-xa.fetch.scmUrl}
+    #pushScmUrl: ${spring-boot-camel-xa.push.scmUrl}
+    #tag: ${spring-boot-camel-xa.tag}
+    #buildCommand: ${spring-boot-camel-xa.buildCommand}
+  project: jboss-fuse/spring-boot-camel-xa
+  scmUrl: git+ssh://code.engineering.redhat.com/jboss-fuse/spring-boot-camel-xa.git
+  externalScmUrl: ssh://git@github.com/jboss-fuse/spring-boot-camel-xa.git
+  scmRevision: spring-boot-camel-xa-${spring-boot-camel-xa.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false -P clean deploy -DskipClean'
+  customPmeParameters:
+    - ${spring-boot-camel-xa.pme.options}
+  dependencies:
+    - redhat-fuse-sb2-${version.fuse.prefix}
+    - narayana-spring-boot-sb2-1.0.2-${version.fuse.prefix}
+
+- name: karaf-camel-amq-sb2-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/karaf-camel-amq
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/karaf-camel-amq.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/karaf-camel-amq.git
+  scmRevision: karaf-camel-amq-${karaf-camel-amq.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${karaf-camel-amq.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: karaf-camel-log-sb2-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/karaf-camel-log
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/karaf-camel-log.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/karaf-camel-log.git
+  scmRevision: karaf-camel-log-${karaf-camel-log.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${karaf-camel-log.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: karaf-camel-rest-sql-sb2-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/karaf-camel-rest-sql
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/karaf-camel-rest-sql.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/karaf-camel-rest-sql.git
+  scmRevision: karaf-camel-rest-sql-${karaf-camel-rest-sql.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${karaf-camel-rest-sql.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: karaf-cxf-rest-sb2-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/karaf-cxf-rest
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/karaf-cxf-rest.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/karaf-cxf-rest.git
+  scmRevision: karaf-cxf-rest-${karaf-cxf-rest.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${karaf-cxf-rest.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: spring-boot-camel-sb2-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/spring-boot-camel
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/spring-boot-camel.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/spring-boot-camel.git
+  scmRevision: spring-boot-camel-${spring-boot-camel.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${spring-boot-camel.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: spring-boot-camel-amq-sb2-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/spring-boot-camel-amq
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/spring-boot-camel-amq.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/spring-boot-camel-amq.git
+  scmRevision: spring-boot-camel-amq-${spring-boot-camel-amq.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${spring-boot-camel-amq.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: spring-boot-camel-config-sb2-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/spring-boot-camel-config
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/sspring-boot-camel-config.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/spring-boot-camel-config.git
+  scmRevision: spring-boot-camel-config-${spring-boot-camel-config.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${spring-boot-camel-config.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: spring-boot-camel-drools-sb2-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/spring-boot-camel-drools
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/spring-boot-camel-drools.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/spring-boot-camel-drools.git
+  scmRevision: sspring-boot-camel-drools-${spring-boot-camel-drools.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${spring-boot-camel-drools.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: spring-boot-camel-infinispan-sb2-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/spring-boot-camel-infinispan
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/spring-boot-camel-infinispan.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/spring-boot-camel-infinispan.git
+  scmRevision: spring-boot-camel-infinispan-${spring-boot-camel-infinispan.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${spring-boot-camel-infinispan.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: spring-boot-camel-rest-sql-sb2-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/spring-boot-camel-rest-sql
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/spring-boot-camel-rest-sql.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/spring-boot-camel-rest-sql.git
+  scmRevision: spring-boot-camel-rest-sql-${spring-boot-camel-rest-sql.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${spring-boot-camel-rest-sql.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: spring-boot-camel-rest-3scale-sb2-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/spring-boot-camel-rest-3scale
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/spring-boot-camel-rest-3scale.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/spring-boot-camel-rest-3scale.git
+  scmRevision: spring-boot-camel-rest-3scale-${spring-boot-camel-rest-3scale.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${spring-boot-camel-rest-3scale.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: spring-boot-camel-xml-sb2-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/spring-boot-camel-xml
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/spring-boot-camel-xml.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/spring-boot-camel-xml.git
+  scmRevision: spring-boot-camel-xml-${spring-boot-camel-xml.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${spring-boot-camel-xml.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: spring-boot-cxf-jaxrs-sb2-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/spring-boot-cxf-jaxrs
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/spring-boot-cxf-jaxrs.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/spring-boot-cxf-jaxrs.git
+  scmRevision: spring-boot-cxf-jaxrs-${spring-boot-cxf-jaxrs.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${spring-boot-cxf-jaxrs.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
+- name: spring-boot-cxf-jaxws-sb2-1.0.0-${version.fuse.prefix}
+  project: fabric8-quickstarts/spring-boot-cxf-jaxws
+  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/spring-boot-cxf-jaxws.git
+  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/spring-boot-cxf-jaxws.git
+  scmRevision: spring-boot-cxf-jaxws-${spring-boot-cxf-jaxws.version}
+  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
+  customPmeParameters:
+    - ${spring-boot-cxf-jaxws.pme.options}
+  dependencies:
+    - redhat-fuse-${version.fuse.prefix}
+
 - name: ipaas-quickstarts-sb2-2.2.0-${version.fuse.prefix}
   project: fabric8io/ipaas-quickstarts
     #fetchScmUrl : ${ipaas-quickstarts.fetch.scmUrl}
@@ -235,22 +405,6 @@ builds:
     - ${narayana-spring-boot.pme.options}
   dependencies:
     - camel-2.23.2-${version.fuse.prefix}
-
-- name: spring-boot-camel-xa-sb2-1.0.0-${version.fuse.prefix}
-    #fetchScmUrl: ${spring-boot-camel-xa.fetch.scmUrl}
-    #pushScmUrl: ${spring-boot-camel-xa.push.scmUrl}
-    #tag: ${spring-boot-camel-xa.tag}
-    #buildCommand: ${spring-boot-camel-xa.buildCommand}
-  project: jboss-fuse/spring-boot-camel-xa
-  scmUrl: git+ssh://code.engineering.redhat.com/jboss-fuse/spring-boot-camel-xa.git
-  externalScmUrl: ssh://git@github.com/jboss-fuse/spring-boot-camel-xa.git
-  scmRevision: spring-boot-camel-xa-${spring-boot-camel-xa.version}
-  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false -P clean deploy -DskipClean'
-  customPmeParameters:
-    - ${spring-boot-camel-xa.pme.options}
-  dependencies:
-    - redhat-fuse-sb2-${version.fuse.prefix}
-    - narayana-spring-boot-sb2-1.0.2-${version.fuse.prefix}
 
 outputPrefixes:
   releaseFile: fuse-test

--- a/src/main/resources/springboot2.yaml
+++ b/src/main/resources/springboot2.yaml
@@ -228,7 +228,7 @@ builds:
   customPmeParameters:
     - ${spring-boot-camel.pme.options}
   dependencies:
-    - redhat-fuse-${version.fuse.prefix}
+    - redhat-fuse-sb2-${version.fuse.prefix}
 
 - name: spring-boot-camel-amq-sb2-1.0.0-${version.fuse.prefix}
   project: fabric8-quickstarts/spring-boot-camel-amq
@@ -239,7 +239,7 @@ builds:
   customPmeParameters:
     - ${spring-boot-camel-amq.pme.options}
   dependencies:
-    - redhat-fuse-${version.fuse.prefix}
+    - redhat-fuse-sb2-${version.fuse.prefix}
 
 - name: spring-boot-camel-drools-sb2-1.0.0-${version.fuse.prefix}
   project: fabric8-quickstarts/spring-boot-camel-drools
@@ -250,7 +250,7 @@ builds:
   customPmeParameters:
     - ${spring-boot-camel-drools.pme.options}
   dependencies:
-    - redhat-fuse-${version.fuse.prefix}
+    - redhat-fuse-sb2-${version.fuse.prefix}
 
 - name: spring-boot-camel-infinispan-sb2-1.0.0-${version.fuse.prefix}
   project: fabric8-quickstarts/spring-boot-camel-infinispan
@@ -261,7 +261,7 @@ builds:
   customPmeParameters:
     - ${spring-boot-camel-infinispan.pme.options}
   dependencies:
-    - redhat-fuse-${version.fuse.prefix}
+    - redhat-fuse-sb2-${version.fuse.prefix}
 
 - name: spring-boot-camel-rest-sql-sb2-1.0.0-${version.fuse.prefix}
   project: fabric8-quickstarts/spring-boot-camel-rest-sql
@@ -272,7 +272,7 @@ builds:
   customPmeParameters:
     - ${spring-boot-camel-rest-sql.pme.options}
   dependencies:
-    - redhat-fuse-${version.fuse.prefix}
+    - redhat-fuse-sb2-${version.fuse.prefix}
 
 - name: spring-boot-camel-rest-3scale-sb2-1.0.0-${version.fuse.prefix}
   project: fabric8-quickstarts/spring-boot-camel-rest-3scale
@@ -283,7 +283,7 @@ builds:
   customPmeParameters:
     - ${spring-boot-camel-rest-3scale.pme.options}
   dependencies:
-    - redhat-fuse-${version.fuse.prefix}
+    - redhat-fuse-sb2-${version.fuse.prefix}
 
 - name: spring-boot-camel-xml-sb2-1.0.0-${version.fuse.prefix}
   project: fabric8-quickstarts/spring-boot-camel-xml
@@ -294,7 +294,7 @@ builds:
   customPmeParameters:
     - ${spring-boot-camel-xml.pme.options}
   dependencies:
-    - redhat-fuse-${version.fuse.prefix}
+    - redhat-fuse-sb2-${version.fuse.prefix}
 
 - name: spring-boot-cxf-jaxrs-sb2-1.0.0-${version.fuse.prefix}
   project: fabric8-quickstarts/spring-boot-cxf-jaxrs
@@ -305,7 +305,7 @@ builds:
   customPmeParameters:
     - ${spring-boot-cxf-jaxrs.pme.options}
   dependencies:
-    - redhat-fuse-${version.fuse.prefix}
+    - redhat-fuse-sb2-${version.fuse.prefix}
 
 - name: spring-boot-cxf-jaxws-sb2-1.0.0-${version.fuse.prefix}
   project: fabric8-quickstarts/spring-boot-cxf-jaxws
@@ -316,7 +316,7 @@ builds:
   customPmeParameters:
     - ${spring-boot-cxf-jaxws.pme.options}
   dependencies:
-    - redhat-fuse-${version.fuse.prefix}
+    - redhat-fuse-sb2-${version.fuse.prefix}
 
 - name: ipaas-quickstarts-sb2-2.2.0-${version.fuse.prefix}
   project: fabric8io/ipaas-quickstarts

--- a/src/main/resources/springboot2.yaml
+++ b/src/main/resources/springboot2.yaml
@@ -219,50 +219,6 @@ builds:
     - redhat-fuse-sb2-${version.fuse.prefix}
     - narayana-spring-boot-sb2-1.0.2-${version.fuse.prefix}
 
-- name: karaf-camel-amq-sb2-1.0.0-${version.fuse.prefix}
-  project: fabric8-quickstarts/karaf-camel-amq
-  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/karaf-camel-amq.git
-  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/karaf-camel-amq.git
-  scmRevision: karaf-camel-amq-${karaf-camel-amq.version}
-  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
-  customPmeParameters:
-    - ${karaf-camel-amq.pme.options}
-  dependencies:
-    - redhat-fuse-${version.fuse.prefix}
-
-- name: karaf-camel-log-sb2-1.0.0-${version.fuse.prefix}
-  project: fabric8-quickstarts/karaf-camel-log
-  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/karaf-camel-log.git
-  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/karaf-camel-log.git
-  scmRevision: karaf-camel-log-${karaf-camel-log.version}
-  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
-  customPmeParameters:
-    - ${karaf-camel-log.pme.options}
-  dependencies:
-    - redhat-fuse-${version.fuse.prefix}
-
-- name: karaf-camel-rest-sql-sb2-1.0.0-${version.fuse.prefix}
-  project: fabric8-quickstarts/karaf-camel-rest-sql
-  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/karaf-camel-rest-sql.git
-  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/karaf-camel-rest-sql.git
-  scmRevision: karaf-camel-rest-sql-${karaf-camel-rest-sql.version}
-  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
-  customPmeParameters:
-    - ${karaf-camel-rest-sql.pme.options}
-  dependencies:
-    - redhat-fuse-${version.fuse.prefix}
-
-- name: karaf-cxf-rest-sb2-1.0.0-${version.fuse.prefix}
-  project: fabric8-quickstarts/karaf-cxf-rest
-  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/karaf-cxf-rest.git
-  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/karaf-cxf-rest.git
-  scmRevision: karaf-cxf-rest-${karaf-cxf-rest.version}
-  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
-  customPmeParameters:
-    - ${karaf-cxf-rest.pme.options}
-  dependencies:
-    - redhat-fuse-${version.fuse.prefix}
-
 - name: spring-boot-camel-sb2-1.0.0-${version.fuse.prefix}
   project: fabric8-quickstarts/spring-boot-camel
   scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/spring-boot-camel.git
@@ -282,17 +238,6 @@ builds:
   buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
   customPmeParameters:
     - ${spring-boot-camel-amq.pme.options}
-  dependencies:
-    - redhat-fuse-${version.fuse.prefix}
-
-- name: spring-boot-camel-config-sb2-1.0.0-${version.fuse.prefix}
-  project: fabric8-quickstarts/spring-boot-camel-config
-  scmUrl: git+ssh://code.engineering.redhat.com/fabric8-quickstarts/sspring-boot-camel-config.git
-  externalScmUrl: ssh://git@github.com/fabric8-quickstarts/spring-boot-camel-config.git
-  scmRevision: spring-boot-camel-config-${spring-boot-camel-config.version}
-  buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean deploy -DskipClean'
-  customPmeParameters:
-    - ${spring-boot-camel-config.pme.options}
   dependencies:
     - redhat-fuse-${version.fuse.prefix}
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ENTESB-9449 suggests that we need the quickstarts as part of the PNC build, so that we can offload the hack-quickstarts type task onto PME.     

Note that this is being committed to the 7-x branch and should not be backported to 7-5-x.

