### PR TITLE
updates to the images.yaml for the next release of Service Registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@
 hs_err_pid*
 
 target
-
+.project
+.settings
 

--- a/src/main/resources/images.yaml
+++ b/src/main/resources/images.yaml
@@ -65,7 +65,7 @@ builds:
   scmUrl: git+ssh://code.engineering.redhat.com/jboss-fuse/apicurio-registry.git
   externalScmUrl: ssh://git@github.com/jboss-fuse/apicurio-registry.git
   scmRevision: apicurio-registry-${version.apicurio-registry}
-  buildScript: 'mvn -B clean deploy dependency:tree -DskipTests -Pprod -Pkafka -Pjpa'
+  buildScript: 'mvn -B clean deploy dependency:tree -DskipTests -Pprod -Pstreams -Pjpa -Pinfinispan'
   customPmeParameters:
     - ${apicurio-registry.pme.options}
 


### PR DESCRIPTION
Updated the build for service registry to include "**streams**" and "**infinispan**" variants and stop building the "**kafka**" variant (which has been deprecated due to the new "**streams**" variant).