### PR TITLE
ENTESB-13020 Define and use a standard template for quickstarts

### DIFF
--- a/pme.properties
+++ b/pme.properties
@@ -28,24 +28,24 @@ apicurito.pme.options=-DscanActiveProfiles=true
 fuse-apicurito-generator.pme.options=-DscanActiveProfiles=true
 narayana-spring-boot.pme.options=-DscanActiveProfiles=true -DdependencyOverride.com.fasterxml.jackson.module:*@*= -DdependencyOverride.com.fasterxml.jackson.jaxrs:*@*= -DdependencyOverride.com.fasterxml.jackson.core:*@*= -DdependencyOverride.com.fasterxml.jackson.jaxrs:*@*= -DdependencyOverride.com.fasterxml.jackson.dataformat:*@*= -DdependencyOverride.com.fasterxml.jackson.datatype:*@*=
 narayana-spring-boot-quickstart.pme.options=-DscanActiveProfiles=true -DdependencyOverride.com.fasterxml.jackson.module:*@*= -DdependencyOverride.com.fasterxml.jackson.jaxrs:*@*= -DdependencyOverride.com.fasterxml.jackson.core:*@*= -DdependencyOverride.com.fasterxml.jackson.jaxrs:*@*= -DdependencyOverride.com.fasterxml.jackson.dataformat:*@*= -DdependencyOverride.com.fasterxml.jackson.datatype:*@*=
-spring-boot-camel-xa.pme.options=-DscanActiveProfiles=true
-karaf-camel-amq.pme.options=-DscanActiveProfiles=true
-karaf-camel-log.pme.options=-DscanActiveProfiles=true
-karaf-camel-rest-sql.pme.options=-DscanActiveProfiles=true
-karaf-cxf-rest.pme.options=-DscanActiveProfiles=true
-spring-boot-camel.pme.options=-DscanActiveProfiles=true
-spring-boot-camel-amq.pme.options=-DscanActiveProfiles=true
-spring-boot-camel-config.pme.options=-DscanActiveProfiles=true
-spring-boot-camel-drools.pme.options=-DscanActiveProfiles=true
-spring-boot-camel-infinispan.pme.options=-DscanActiveProfiles=true
-spring-boot-camel-rest-sql.pme.options=-DscanActiveProfiles=true
-spring-boot-camel-rest-3scale=-DscanActiveProfiles=true
-spring-boot-camel-xml.pme.options=-DscanActiveProfiles=true
-spring-boot-camel-soap-rest-bridge.pme.options=-DscanActiveProfiles=true
-spring-boot-cxf-jaxrs.pme.options=-DscanActiveProfiles=true
-spring-boot-cxf-jaxws.pme.options=-DscanActiveProfiles=true
-spring-boot-cxf-jaxrs-xml.pme.options=-DscanActiveProfiles=true
-spring-boot-cxf-jaxws-xml.pme.options=-DscanActiveProfiles=true
+spring-boot-camel-xa.pme.options=-DscanActiveProfiles=true -DgroovyScripts=https://gitlab.cee.redhat.com/jondruse/alignment-automation/-/raw/master/src/main/groovy/com/redhat/fuse/groovy/pmeAlterReadme.groovy
+karaf-camel-amq.pme.options=-DscanActiveProfiles=true -DgroovyScripts=https://gitlab.cee.redhat.com/jondruse/alignment-automation/-/raw/master/src/main/groovy/com/redhat/fuse/groovy/pmeAlterReadme.groovy
+karaf-camel-log.pme.options=-DscanActiveProfiles=true -DgroovyScripts=https://gitlab.cee.redhat.com/jondruse/alignment-automation/-/raw/master/src/main/groovy/com/redhat/fuse/groovy/pmeAlterReadme.groovy
+karaf-camel-rest-sql.pme.options=-DscanActiveProfiles=true -DgroovyScripts=https://gitlab.cee.redhat.com/jondruse/alignment-automation/-/raw/master/src/main/groovy/com/redhat/fuse/groovy/pmeAlterReadme.groovy
+karaf-cxf-rest.pme.options=-DscanActiveProfiles=true -DgroovyScripts=https://gitlab.cee.redhat.com/jondruse/alignment-automation/-/raw/master/src/main/groovy/com/redhat/fuse/groovy/pmeAlterReadme.groovy
+spring-boot-camel.pme.options=-DscanActiveProfiles=true -DgroovyScripts=https://gitlab.cee.redhat.com/jondruse/alignment-automation/-/raw/master/src/main/groovy/com/redhat/fuse/groovy/pmeAlterReadme.groovy
+spring-boot-camel-amq.pme.options=-DscanActiveProfiles=true -DgroovyScripts=https://gitlab.cee.redhat.com/jondruse/alignment-automation/-/raw/master/src/main/groovy/com/redhat/fuse/groovy/pmeAlterReadme.groovy
+spring-boot-camel-config.pme.options=-DscanActiveProfiles=true -DgroovyScripts=https://gitlab.cee.redhat.com/jondruse/alignment-automation/-/raw/master/src/main/groovy/com/redhat/fuse/groovy/pmeAlterReadme.groovy
+spring-boot-camel-drools.pme.options=-DscanActiveProfiles=true -DgroovyScripts=https://gitlab.cee.redhat.com/jondruse/alignment-automation/-/raw/master/src/main/groovy/com/redhat/fuse/groovy/pmeAlterReadme.groovy
+spring-boot-camel-infinispan.pme.options=-DscanActiveProfiles=true -DgroovyScripts=https://gitlab.cee.redhat.com/jondruse/alignment-automation/-/raw/master/src/main/groovy/com/redhat/fuse/groovy/pmeAlterReadme.groovy
+spring-boot-camel-rest-sql.pme.options=-DscanActiveProfiles=true -DgroovyScripts=https://gitlab.cee.redhat.com/jondruse/alignment-automation/-/raw/master/src/main/groovy/com/redhat/fuse/groovy/pmeAlterReadme.groovy
+spring-boot-camel-rest-3scale=-DscanActiveProfiles=true -DgroovyScripts=https://gitlab.cee.redhat.com/jondruse/alignment-automation/-/raw/master/src/main/groovy/com/redhat/fuse/groovy/pmeAlterReadme.groovy
+spring-boot-camel-xml.pme.options=-DscanActiveProfiles=true -DgroovyScripts=https://gitlab.cee.redhat.com/jondruse/alignment-automation/-/raw/master/src/main/groovy/com/redhat/fuse/groovy/pmeAlterReadme.groovy
+spring-boot-camel-soap-rest-bridge.pme.options=-DscanActiveProfiles=true -DgroovyScripts=https://gitlab.cee.redhat.com/jondruse/alignment-automation/-/raw/master/src/main/groovy/com/redhat/fuse/groovy/pmeAlterReadme.groovy
+spring-boot-cxf-jaxrs.pme.options=-DscanActiveProfiles=true -DgroovyScripts=https://gitlab.cee.redhat.com/jondruse/alignment-automation/-/raw/master/src/main/groovy/com/redhat/fuse/groovy/pmeAlterReadme.groovy
+spring-boot-cxf-jaxws.pme.options=-DscanActiveProfiles=true -DgroovyScripts=https://gitlab.cee.redhat.com/jondruse/alignment-automation/-/raw/master/src/main/groovy/com/redhat/fuse/groovy/pmeAlterReadme.groovy
+spring-boot-cxf-jaxrs-xml.pme.options=-DscanActiveProfiles=true -DgroovyScripts=https://gitlab.cee.redhat.com/jondruse/alignment-automation/-/raw/master/src/main/groovy/com/redhat/fuse/groovy/pmeAlterReadme.groovy
+spring-boot-cxf-jaxws-xml.pme.options=-DscanActiveProfiles=true -DgroovyScripts=https://gitlab.cee.redhat.com/jondruse/alignment-automation/-/raw/master/src/main/groovy/com/redhat/fuse/groovy/pmeAlterReadme.groovy
 camel-k-runtime.pme.options=-DscanActiveProfiles=true -DdependencyOverride.javax.ws.rs:*@*= -DdependencyOverride.com.fasterxml.jackson.dataformat:*@*= -DdependencyOverride.com.fasterxml.jackson.core:*@*= -DdependencyOverride.com.fasterxml.jackson.datatype:*@*=
 #
 atlasmap.pme.options=-DdependencyOverride.com.sun.xml.bind:*@*= -DdependencyOverride.com.fasterxml.jackson.core:*@*= -DdependencyOverride.com.fasterxml.jackson.module:*@*= -DdependencyOverride.org.ow2.asm:*@*= -DdependencyOverride.javax.ws.rs:*@*= -DprojectMetaSkip=true


### PR DESCRIPTION
Issue https://issues.redhat.com/browse/ENTESB-13020

Adds alignment script https://gitlab.cee.redhat.com/jondruse/alignment-automation/-/raw/master/src/main/groovy/com/redhat/fuse/groovy/pmeAlterReadme.groovy to quickstarts. Script aligns version in documentation link and in command `oc import image`