### PR TITLE
Upgrade env id for cxf build to 48 - we need to use a newer OpenJDK

### DIFF
--- a/src/main/resources/common.yaml
+++ b/src/main/resources/common.yaml
@@ -7,7 +7,7 @@ version: ${version.fuse.prefix}
 milestone: ${build.milestone}
 group: Red Hat Fuse - Common ${version.fuse.project} TP3 ${build.milestone}
 defaultBuildParameters:
-  environmentId: 39
+  environmentId: 48
   buildScript: 'mvn -e -V -B -DskipTests -DfailIfNoTests=false -Dtest=false clean
     deploy'
 
@@ -21,7 +21,7 @@ builds:
   scmUrl: git+ssh://code.engineering.redhat.com/jboss-fuse/cxf.git
   externalScmUrl: ssh://git@github.com/jboss-fuse/cxf.git
   scmRevision: cxf-${version.cxf}
-  environmentId: 39
+  environmentId: 48
   pigYamlMetadata: Fuse dev build ${build.url} Fuse ${yaml.name} yaml config ${project.version}
   alignmentParameters:
     - ${cxf.pme.options}


### PR DESCRIPTION
Upgrade env id for cxf build to 48 - we need to use a newer OpenJDK than OpenJDK 11.0 - env 48 is openjdk 11.0.9 and mvn 3.6.0.   It'd be preferable to use mvn 3.6.3, but 3.6.0 is the most recent I can find with openjdk 11.0.9.