### PR TITLE
Add dependencies to kubernetes-client and arquillian-cube to prevent build order failures

### DIFF
--- a/src/main/resources/base.yaml
+++ b/src/main/resources/base.yaml
@@ -113,6 +113,8 @@ builds:
   pigYamlMetadata: Fuse dev build ${build.url} Fuse ${yaml.name} yaml config ${project.version}
   customPmeParameters:
     - ${arquillian-cube.pme.options}
+  dependencies:
+    - kubernetes-client-4.6.2-${version.fuse.prefix}
 
 outputPrefixes:
   releaseFile: fuse-test

--- a/src/main/resources/base.yaml
+++ b/src/main/resources/base.yaml
@@ -99,6 +99,9 @@ builds:
   pigYamlMetadata: Fuse dev build ${build.url} Fuse ${yaml.name} yaml config ${project.version}
   customPmeParameters:
     - ${kubernetes-client.pme.options}
+  dependencies:
+    - karaf-4.2.9-${version.fuse.prefix}
+
 
 - name: arquillian-cube-1.18.2-${version.fuse.prefix}
   project: jboss-fuse/arquillian-cube


### PR DESCRIPTION
Add dependencies to kubernetes-client and arquillian-cube to prevent build order failures