### PR TITLE
feat: remove ci directory after build

### DIFF
--- a/src/main/resources/camelk.yaml
+++ b/src/main/resources/camelk.yaml
@@ -56,7 +56,7 @@ builds:
   environmentId: 308
   pigYamlMetadata: Fuse dev build ${build.url} Fuse ${yaml.name} yaml config ${project.version}
   buildScript: >
-   sed -i "s/-ldflags/-mod=vendor -ldflags/g" Makefile; mvn clean package deploy -Pgolang-build -Durl=${AProxDeployUrl} -DrepositoryId=indy-mvn dependency:tree
+   sed -i "s/-ldflags/-mod=vendor -ldflags/g" Makefile; mvn clean package deploy -f ci/pnc/pom.xml -Pgolang-build -Durl=${AProxDeployUrl} -DrepositoryId=indy-mvn dependency:tree; rm -rf ci
   alignmentParameters:
     - ${camel-k.pme.options}
   dependencies:


### PR DESCRIPTION
With this PR we are using a pom as provided in https://github.com/jboss-fuse/camel-k/pull/72 removing the entire directory once the build is over in order not to be included in the distribution source archive.

Closes ENTESB-17931