### PR TITLE
Update camelk.yaml

### DIFF
--- a/src/main/resources/camelk.yaml
+++ b/src/main/resources/camelk.yaml
@@ -56,7 +56,7 @@ builds:
   environmentId: 308
   pigYamlMetadata: Fuse dev build ${build.url} Fuse ${yaml.name} yaml config ${project.version}
   buildScript: >
-   sed -i "s/-ldflags/-mod=vendor -ldflags/g" Makefile; mvn clean package deploy -f ci/pnc/pom.xml -Pgolang-build -Durl=${AProxDeployUrl} -DrepositoryId=indy-mvn dependency:tree; rm -rf ci
+   sed -i "s/-ldflags/-mod=vendor -ldflags/g" Makefile; mvn clean package deploy -f ci/pnc/pom.xml -Pgolang-build -Durl=${AProxDeployUrl} -DrepositoryId=indy-mvn dependency:tree
   alignmentParameters:
     - ${camel-k.pme.options}
   dependencies:


### PR DESCRIPTION
With this PR we should let the `/ci/` dir to be included in PNC. However, we must find a way to exclude such dir from the inclusion in MRRC archive.