### PR TITLE
Remove useless pom deletion

### DIFF
--- a/src/main/resources/camelk.yaml
+++ b/src/main/resources/camelk.yaml
@@ -56,7 +56,7 @@ builds:
   environmentId: 308
   pigYamlMetadata: Fuse dev build ${build.url} Fuse ${yaml.name} yaml config ${project.version}
   buildScript: >
-   sed -i "s/-ldflags/-mod=vendor -ldflags/g" Makefile; mvn clean package deploy -Pgolang-build -Durl=${AProxDeployUrl} -DrepositoryId=indy-mvn dependency:tree; rm -f pom.xml
+   sed -i "s/-ldflags/-mod=vendor -ldflags/g" Makefile; mvn clean package deploy -Pgolang-build -Durl=${AProxDeployUrl} -DrepositoryId=indy-mvn dependency:tree
   alignmentParameters:
     - ${camel-k.pme.options}
   dependencies:


### PR DESCRIPTION
Originally added to see if it excluded from the MRRC. Did not work, as the MRRC archive from the git repo.