### PR TITLE
Add a dependency on the singleton quickstart to ipaas-quickstarts

### DIFF
--- a/src/main/resources/springboot2.yaml
+++ b/src/main/resources/springboot2.yaml
@@ -593,6 +593,7 @@ builds:
   - spring-boot-camel-rhosak-1.0.0-${version.fuse.prefix}
   - spring-boot-camel-xml-1.0.0-${version.fuse.prefix}
   - spring-boot-camel-soap-rest-bridge-1.0.0-${version.fuse.prefix}
+  - spring-boot-camel-singleton-services-kubernetes-1.0.0-${version.fuse.prefix}
   - spring-boot-cxf-jaxrs-1.0.0-${version.fuse.prefix}
   - spring-boot-cxf-jaxws-1.0.0-${version.fuse.prefix}
   - spring-boot-cxf-jaxrs-xml-1.0.0-${version.fuse.prefix}


### PR DESCRIPTION
I think the reason for https://issues.redhat.com/browse/ENTESB-18710 may be that the singleton quickstart was not built before application-templates or ipaas-quickstarts tried to align.      It looks like we built 7.11.0.fuse-sb2-7_11_0-00010-redhat-00001 and application-templates contained version 

    <spring-boot-2-camel-singleton-services-kubernetes.version>7.11.0.fuse-sb2-7_11_0-00010</spring-boot-2-camel-singleton-services-kubernetes.version>

I think between this change and the change here, we will have solved the alignment problem for the singleton quickstart 

https://github.com/jboss-fuse/fuse-jenkins-pipelines/commit/aaa35b45ebe4e5f0dd9491a0e59f3e63a68016f4