### PR TITLE
Adding dependency:tree to camel and cxf project builds so build from source percentage can be computed

### DIFF
--- a/src/main/resources/springboot2.yaml
+++ b/src/main/resources/springboot2.yaml
@@ -26,7 +26,7 @@ builds:
   alignmentParameters:
     - ${cxf.pme.options}
   buildScript: >
-    mvn -e -V -B -Dmaven.test.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dassembly.tarLongFileMode=posix -DfailIfNoTests=false -Dtest=false -Dcxf.public.suffix.list.url=http://download.devel.redhat.com/rcm-guest/staging/fuse/npm/public_suffix_list.dat -Pdeploy clean deploy
+    mvn -e -V -B -Dmaven.test.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dassembly.tarLongFileMode=posix -DfailIfNoTests=false -Dtest=false -Dcxf.public.suffix.list.url=http://download.devel.redhat.com/rcm-guest/staging/fuse/npm/public_suffix_list.dat -Pdeploy clean deploy dependency:tree
 
 - name: camel-2.23.2-${version.fuse.prefix}
   project: jboss-fuse/camel
@@ -44,7 +44,7 @@ builds:
     export MAVEN_OPTS="-Xmx4g"
 
     mvn -e -V -B  -Dmaven.test.skip.exec=true -DfailIfNoTests=false -Dtest=false -Penable-schemagen,release,apt
-    clean deploy -DkeepStagingRepositoryOnCloseRuleFailure=true -Dgpg.skip=true -pl
+    clean deploy dependency:tree -DkeepStagingRepositoryOnCloseRuleFailure=true -Dgpg.skip=true -pl
     '!org.apache.camel:camel-itest'
   buildPodMemory: 12
   alignmentParameters:


### PR DESCRIPTION
I want to add a dependency:tree goal onto the maven command that is executed for cxf and for camel so that we can compute the build from source percentage from the build log.