### PR TITLE
Update environmentIds to non-deprecated versions

### DIFF
--- a/src/main/resources/base.yaml
+++ b/src/main/resources/base.yaml
@@ -7,7 +7,7 @@ version: ${version.fuse.prefix}
 milestone: ${build.milestone}
 group: Red Hat Fuse - Base ${version.fuse.project} ${build.milestone}
 defaultBuildParameters:
-  environmentId: 8
+  environmentId: 654
   buildScript: 'mvn -e -V -B -Dmaven.test.skip=true -DfailIfNoTests=false -Dtest=false clean 
     deploy '
 

--- a/src/main/resources/boosters-sb2.yaml
+++ b/src/main/resources/boosters-sb2.yaml
@@ -7,7 +7,7 @@ version: ${version.fuse.prefix}
 milestone: ${build.milestone}
 group: Red Hat Fuse - Boosters SB2 ${version.fuse.project} ${build.milestone}
 defaultBuildParameters:
-  environmentId: 8
+  environmentId: 654
   buildScript: 'mvn -e -V -B -Dmaven.test.skip=true -DfailIfNoTests=false -Dtest=false clean
     deploy'
 

--- a/src/main/resources/boosters.yaml
+++ b/src/main/resources/boosters.yaml
@@ -7,7 +7,7 @@ version: ${version.fuse.prefix}
 milestone: ${build.milestone}
 group: Red Hat Fuse - Boosters ${version.fuse.project} ${build.milestone}
 defaultBuildParameters:
-  environmentId: 8
+  environmentId: 654
   buildScript: 'mvn -e -V -B -Dmaven.test.skip=true -DfailIfNoTests=false -Dtest=false clean
     deploy'
 

--- a/src/main/resources/ipaas.yaml
+++ b/src/main/resources/ipaas.yaml
@@ -7,7 +7,7 @@ version: ${version.fuse.prefix}
 milestone: ${build.milestone}
 group: Red Hat Fuse - iPaaS ${version.fuse.project} ${build.milestone}
 defaultBuildParameters:
-  environmentId: 7
+  environmentId: 419
   buildScript: 'mvn -e -V -B -Dmaven.test.skip=true -DfailIfNoTests=false -Dtest=false clean
     deploy '
 
@@ -22,7 +22,7 @@ builds:
   scmUrl: git+ssh://code.engineering.redhat.com/jboss-fuse/syndesis.git
   scmRevision: syndesis-${version.syndesis}
   buildPodMemory: 12
-  environmentId: 34
+  environmentId: 662
   alignmentParameters:
     - ${syndesis.pme.options}
   buildScript: >

--- a/src/main/resources/springboot2.yaml
+++ b/src/main/resources/springboot2.yaml
@@ -7,7 +7,7 @@ version: ${version.fuse.prefix}
 milestone: ${build.milestone}
 group: Red Hat Fuse - Spring Boot 2 ${version.fuse.project} ${build.milestone}
 defaultBuildParameters:
-  environmentId: 8
+  environmentId: 654
   buildScript: 'mvn -e -V -B -Dmaven.test.skip=true -DfailIfNoTests=false -Dtest=false clean
     deploy '
 
@@ -190,7 +190,7 @@ builds:
   scmUrl: git+ssh://code.engineering.redhat.com/jboss-fuse/wildfly-camel.git
   externalScmUrl: ssh://git@github.com/jboss-fuse/wildfly-camel.git
   scmRevision: wildfly-camel-${version.bom.wildfly.camel}
-  environmentId: 33
+  environmentId: 660
   pigYamlMetadata: Fuse dev build ${build.url} Fuse ${yaml.name} yaml config ${project.version}
   buildScript: >
     export JAVA_TOOL_OPTIONS="-Xmx3g"
@@ -272,7 +272,7 @@ builds:
   scmUrl: git+ssh://code.engineering.redhat.com/wildfly-extras/wildfly-camel-examples.git
   externalScmUrl: ssh://git@github.com/wildfly-extras/wildfly-camel-examples.git
   scmRevision: wildfly-camel-examples-${version.wildfly.camel.examples}
-  environmentId: 33
+  environmentId: 660
   pigYamlMetadata: Fuse dev build ${build.url} Fuse ${yaml.name} yaml config ${project.version}
   buildScript: >
     export M2_HOME=/usr/share/maven
@@ -293,7 +293,7 @@ builds:
   scmUrl: git+ssh://code.engineering.redhat.com/jboss-fuse/fuse-eap.git
   externalScmUrl: ssh://git@github.com/jboss-fuse/fuse-eap.git
   scmRevision: fuse-eap-${version.fuse.eap}
-  environmentId: 33
+  environmentId: 660
   pigYamlMetadata: Fuse dev build ${build.url} Fuse ${yaml.name} yaml config ${project.version}
   buildScript: >
     export M2_HOME=/usr/share/maven


### PR DESCRIPTION
According to Dustin : 

```
so unfortunately, in these older builder images, we applied a fix to disable some tls algorithm due to a bug in JDK. That bug has since been fixed but the disabling stayed. this unfortunately affects communication with [auth.redhat.com](http://auth.redhat.com/)

So we need to use the latest images for JDK 8 type of builds.
```

Updating the images to most recent versions after finding the current versions in the deprecation map.